### PR TITLE
Limit the version of numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-numpy
+# onnxruntime doesn't support numpy>=2.0.0. The restriction will be removed once they fix it.
+numpy<2.0.0
 onnx
 onnxruntime
 onnxruntime-extensions

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
             "onnxruntime",
             "onnxruntime-extensions",
             "psutil",
-            "numpy",
+            "numpy<2.0.0",
             "py-cpuinfo",
             "pydantic",
             "transformers",


### PR DESCRIPTION
## Type of Change

bug fix 
API changed or not: no

## Description

Limit the version of numpy<2.0.0.
`onnxruntime` doesn't support `numpy>=2.0.0` now. The restriction will be removed once they fix it.


## How has this PR been tested?

CI

## Dependency Change?

no
