### PR TITLE
enhancements: sharing mine

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ Memory and speed:
   sample; wide alpha grids no longer balloon ORT arena memory or rebuild time.
 - **Per-node activation caching across the alpha grid** so each alpha evaluation
   does not re-harvest the same reference activations.
+- **The large-model alpha search never touches the model proto.** Each (node, alpha)
+  evaluation used to rewrite the node's weight initializer twice (scale then recover),
+  and even plain `numpy_helper.to_array` reads materialize external weights into the
+  proto. Under protobuf's upb backend every such write abandons the old bytes in the
+  ModelProto's arena (freed only when the whole proto dies), so retained RAM grew with
+  nodes x alphas and survived into static calibration: a 0.1-step grid OOMed a real
+  encoder export where a 0.2-step grid fit. Candidate weights are now scaled in numpy
+  and fed to the QDQ-loss session directly, and external weights are read via a
+  throwaway TensorProto, so the search retains nothing.
 
 Features:
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Correctness:
   activations are cached (also fixes the large-model path).
 - **The alpha grid includes both endpoints**: upstream's `np.arange` stopped one
   step short of `alpha_max`, so the maximum alpha was never evaluated.
+- **The selected execution provider reaches the smoother calibration.** The
+  smoother passed `execution_provider=` to the `Calibrator`, whose constructor
+  parameter is `providers=`, so the argument fell into `**kwargs` and was
+  silently dropped: every smoother-calibration forward ran on the
+  `CPUExecutionProvider` even when the caller selected CUDA. The provider list is
+  now forwarded, so `--ep cuda` actually calibrates on the GPU.
 
 Memory and speed:
 
@@ -63,6 +69,35 @@ Memory and speed:
   encoder export where a 0.2-step grid fit. Candidate weights are now scaled in numpy
   and fed to the QDQ-loss session directly, and external weights are read via a
   throwaway TensorProto, so the search retains nothing.
+- **Memory-conservative calibration sessions.** The augmented dump graphs return
+  hundreds of activation tensors per forward and ORT's BFC arenas grow ahead of
+  demand (power-of-two extends) and never release, so the calibration sessions
+  carried ~1 GB of pure allocator slack on a 0.6B encoder and could abort with a
+  BFCArena "Failed to allocate memory" on a loaded host. These sessions run only a
+  handful of forwards, so the allocator-speed trade is free:
+  `conservative_session_resources()` disables the CPU arena and pins the CUDA
+  arena to `kSameAsRequested` growth (with the heuristic cuDNN algo search),
+  applied to both the static-calibration session and the smoother's dump session.
+- **Streaming per-channel percentile in the smoother calibration.** The smoother
+  calibration stacked every collected sample's activations and called
+  `np.percentile` once at the end, so RAM grew as samples x frames x channels
+  (~6 GB per ~400 s window, hundreds of GB for a multi-window export) and
+  swap-thrashed mid-pass. Because the high percentiles SmoothQuant uses (99.999 by
+  default) depend only on the largest values per channel, each sample is now
+  folded into a per-channel running top-K reducer (`StreamingChannelPercentile`)
+  and freed; the reducer reproduces `np.percentile` bit-for-bit (its float64
+  promotion and `t >= 0.5` lerp branch included) and re-checks that K was large
+  enough for the actual row count, so a result can never be silently wrong.
+- **Sliced static-calibration dump to bound VRAM.** Static int8 calibration
+  augments the model so EVERY calibrated tensor becomes a graph output, and ORT
+  keeps all graph outputs resident for the whole forward, so a long calibration
+  window peaks every activation at once (the per-layer attention-score MatMuls are
+  ~0.8 GB each near a FastConformer's ~400 s reach) and overflows GPU VRAM. With
+  `dump_batch_size > 0` (the `CalibDumpBatch` extra_option) the calibrated tensors
+  are dumped in slices of that many graph outputs, each slice its own augment +
+  forward over the same (rewound) windows, so only one slice is resident at a
+  time; the per-tensor calibration ranges stay bit-identical to the single-pass
+  dump (it only trades extra forwards for a smaller peak).
 
 Features:
 
@@ -76,6 +111,22 @@ Features:
   nodes (`Smoother.auto_alpha_losses`). Setting the option to an int n (or a
   fraction in (0, 1)) keeps the n worst-quantizing nodes out of quantization
   entirely, trading a little file size for accuracy on the layers int8 hurts most.
+- **Resumable, crash-safe exports.** Given a checkpoint directory
+  (`extra_options["SmoothQuantCheckpointDir"]` plus
+  `CalibParamsCheckpointFile`), the smoother persists its expensive intermediates
+  as they are produced and reloads whatever already exists on the next run: the
+  smoother calibration, the per-node alpha search (append-only `alphas.jsonl`, one
+  line per completed node grid so an interrupted multi-hour search resumes from
+  the last completed node), and the static-calibration quantization params. Both
+  per-sample calibration loops also checkpoint MID-pass, time-gated by
+  `CheckpointIntervalSec` (default 1200 s) so a fast pass pays no IO, so an OOM- or
+  time-killed pass resumes from the last sample instead of restarting. All writes
+  are atomic (temp + `os.replace`) so a crash mid-write never leaves a truncated
+  file. Checkpoints carry no model fingerprint (the caller keys the directory by
+  its full run configuration and owns invalidation) but DO record the slice
+  partition that produced the static-calibration partial, so a resume with a
+  changed `CalibDumpBatch` or tensor set is discarded rather than applied to the
+  wrong slices.
 - **Richer quantization statistics table**: fp32 ops are split into "quantizable"
   (weight-bearing, the quantizer could convert them directly) versus "needs an
   int8 input" (weightless/pass-through ops that only convert inside an int8

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-<div align="center">
-
 Neural Compressor
 ===========================
 <h3> An open-source Python library supporting popular model compression techniques for ONNX</h3>
@@ -10,7 +8,6 @@ Neural Compressor
 
 
 ---
-<div align="left">
 
 ## About this fork
 
@@ -138,123 +135,3 @@ The changes are regression-tested from the model repo
 ([`scripts/test_quantize-int8-smoothquant.py`](https://huggingface.co/Olicorne/parakeet-tdt-0.6b-v3-smoothquant-onnx/blob/main/scripts/test_quantize-int8-smoothquant.py)).
 This fork was developed with [Claude Code](https://claude.com/claude-code).
 The original upstream README follows.
-
----
-
-Neural Compressor aims to provide popular model compression techniques inherited from [Intel Neural Compressor](https://github.com/intel/neural-compressor) yet focused on ONNX model quantization such as SmoothQuant, weight-only quantization through [ONNX Runtime](https://onnxruntime.ai/). In particular, the tool provides the key features, typical examples, and open collaborations as below:
-
-* Support a wide range of Intel hardware such as [Intel Xeon Scalable Processors](https://www.intel.com/content/www/us/en/products/details/processors/xeon/scalable.html) and AIPC
-
-* Validate popular LLMs such as [LLama2](./examples/nlp/huggingface_model/text_generation/), [Llama3](./examples/nlp/huggingface_model/text_generation/), [Qwen2](./examples/nlp/huggingface_model/text_generation/) and broad models such as [BERT-base](./examples/nlp/bert/quantization), and [ResNet50](./examples/image_recognition/resnet50/quantization/ptq_static) from popular model hubs such as [Hugging Face](https://huggingface.co/), [ONNX Model Zoo](https://github.com/onnx/models#models), by leveraging automatic [accuracy-driven](./docs/design.md#workflow) quantization strategies
-
-* Collaborate with software platforms such as [Microsoft Olive](https://github.com/microsoft/Olive), and open AI ecosystem such as [Hugging Face](https://huggingface.co/blog/intel), [ONNX](https://github.com/onnx/models#models) and [ONNX Runtime](https://github.com/microsoft/onnxruntime)
-
-## Installation
-
-### Install from source
-```Shell
-git clone https://github.com/onnx/neural-compressor.git
-cd neural-compressor
-pip install -r requirements.txt
-pip install .
-```
-
-> **Note**:
-> Further installation methods can be found under [Installation Guide](./docs/installation_guide.md).
-
-## Getting Started
-
-Setting up the environment:
-```bash
-pip install onnx-neural-compressor "onnxruntime>=1.17.0" onnx
-```
-After successfully installing these packages, try your first quantization program.
-> Notes: please install from source before the formal pypi release.
-
-### Weight-Only Quantization (LLMs)
-Following example code demonstrates Weight-Only Quantization on LLMs, device will be selected for efficiency automatically when multiple devices are available.
-
-Run the example:
-```python
-from onnx_neural_compressor.quantization import matmul_nbits_quantizer
-
-algo_config = matmul_nbits_quantizer.RTNWeightOnlyQuantConfig()
-quant = matmul_nbits_quantizer.MatMulNBitsQuantizer(
-    model,
-    n_bits=4,
-    block_size=32,
-    is_symmetric=True,
-    algo_config=algo_config,
-)
-quant.process()
-best_model = quant.model
-```
-
-### Static Quantization
-
-```python
-from onnx_neural_compressor.quantization import quantize, config
-from onnx_neural_compressor import data_reader
-
-
-class DataReader(data_reader.CalibrationDataReader):
-    def __init__(self):
-        self.encoded_list = []
-        # append data into self.encoded_list
-
-        self.iter_next = iter(self.encoded_list)
-
-    def get_next(self):
-        return next(self.iter_next, None)
-
-    def rewind(self):
-        self.iter_next = iter(self.encoded_list)
-
-
-data_reader = DataReader()
-qconfig = config.StaticQuantConfig(calibration_data_reader=data_reader)
-quantize(model, output_model_path, qconfig)
-```
-
-## Documentation
-
-<table class="docutils">
-  <thead>
-  <tr>
-    <th colspan="8">Overview</th>
-  </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td colspan="3" align="center"><a href="./docs/design.md#architecture">Architecture</a></td>
-      <td colspan="3" align="center"><a href="./docs/design.md#workflow">Workflow</a></td>
-      <td colspan="3" align="center"><a href="./examples/">Examples</a></td>
-    </tr>
-  </tbody>
-  <thead>
-    <tr>
-      <th colspan="8">Feature</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-        <td colspan="4" align="center"><a href="./docs/quantization.md">Quantization</a></td>
-          <td colspan="4" align="center"><a href="./docs/smooth_quant.md">SmoothQuant</td>
-      <tr>
-          <td colspan="4" align="center"><a href="./docs/quantization_weight_only.md">Weight-Only Quantization (INT8/INT4) </td>
-           </td>
-          <td colspan="4" align="center"><a href="./docs/quantization_layer_wise.md">Layer-Wise Quantization </td>
-      </tr>
-  </tbody>
-</table>
-
-
-
-## Additional Content
-
-* [Contribution Guidelines](./docs/source/CONTRIBUTING.md)
-* [Security Policy](SECURITY.md)
-
-## Communication
-- [GitHub Issues](https://github.com/onnx/neural-compressor/issues): mainly for bug reports, new feature requests, question asking, etc.
-- [Email](mailto:inc.maintainers@intel.com): welcome to raise any interesting research ideas on model compression techniques by email for collaborations.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Features:
   fixed alpha, or give it its own `min:max:step` grid).
 - **Per-layer alpha summary** logged after the search (histogram per op type plus
   one line per smoothed node).
+- **Sensitivity-based mixed precision** (`extra_options["SmoothQuantExcludeWorst"]`):
+  the auto-alpha search records every smoothed node's best achievable QDQ loss,
+  normalized by that node's reference-output energy so it is comparable across
+  nodes (`Smoother.auto_alpha_losses`). Setting the option to an int n (or a
+  fraction in (0, 1)) keeps the n worst-quantizing nodes out of quantization
+  entirely, trading a little file size for accuracy on the layers int8 hurts most.
 - **Richer quantization statistics table**: fp32 ops are split into "quantizable"
   (weight-bearing, the quantizer could convert them directly) versus "needs an
   int8 input" (weightless/pass-through ops that only convert inside an int8

--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ Correctness:
   silently dropped: every smoother-calibration forward ran on the
   `CPUExecutionProvider` even when the caller selected CUDA. The provider list is
   now forwarded, so `--ep cuda` actually calibrates on the GPU. (commit [`ad8c01b`](https://github.com/thiswillbeyourgithub/neural-compressor-fork/commit/ad8c01b))
+- **SmoothQuant `extra_options` are no longer silently ignored.** `quantize()`
+  routes a `StaticQuantConfig` (with `extra_options["SmoothQuant"]`) into
+  `smooth_quant_entry`, which called
+  `smoother.transform(**quant_config.get_model_params_dict())`. But
+  `get_model_params_dict()` only surfaces the static-quant knobs, so NONE of the
+  smooth knobs (`SmoothQuantAlpha`, `SmoothQuantOpTypes`, `AutoAlphaArgs`, ...)
+  reached `transform()`: the smoother always ran with its hard-coded defaults
+  (`alpha=0.5`, the `[0.3, 0.7]` auto grid, op types Conv+Gemm+MatMul+FusedConv)
+  no matter what the caller set. A new `_smoothquant_transform_params()` maps the
+  documented `extra_options` names to the `transform()` argument names so they
+  take effect. (commit [`d6745e4`](https://github.com/thiswillbeyourgithub/neural-compressor-fork/commit/d6745e4))
 
 Memory and speed:
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,60 @@ Neural Compressor
 ---
 <div align="left">
 
+## About this fork
+
+This is a fork of [onnx/neural-compressor](https://github.com/onnx/neural-compressor)
+whose `diy` branch fixes and speeds up the **SmoothQuant static int8 path**. It is
+used (vendored as a submodule) to build the SmoothQuant int8 Parakeet TDT 0.6B v3
+ASR encoder published at
+[Olicorne/parakeet-tdt-0.6b-v3-smoothquant-onnx](https://huggingface.co/Olicorne/parakeet-tdt-0.6b-v3-smoothquant-onnx),
+which serves the browser app
+[parakeet_web](https://github.com/thiswillbeyourgithub/parakeet_web). The changes
+are candidates for upstream PRs; until those exist, here is what `diy` changes
+versus the upstream repo:
+
+Correctness:
+
+- **Auto-alpha search no longer runs on an exhausted dataloader.** Upstream's
+  `alpha="auto"` consumed the calibration reader before the search, so every layer
+  silently got `alpha_min`; the reader is now rewound and the per-node reference
+  activations are cached (also fixes the large-model path).
+- **The alpha grid includes both endpoints**: upstream's `np.arange` stopped one
+  step short of `alpha_max`, so the maximum alpha was never evaluated.
+
+Memory and speed:
+
+- **Streaming Entropy/Percentile calibration.** Static calibration used to buffer
+  every dumped activation tensor of every calibration sample until the end of the
+  loop (an in-code upstream TODO), so RAM grew linearly with samples x dumped
+  tensors and large exports OOMed. Each sample is now folded straight into the
+  per-tensor histogram; peak RAM no longer depends on the sample count.
+- **The auto-alpha QDQ sub-graph session is built once per node** (weights fed as
+  runtime inputs), not once per (node, alpha) and originally once per calibration
+  sample; wide alpha grids no longer balloon ORT arena memory or rebuild time.
+- **Per-node activation caching across the alpha grid** so each alpha evaluation
+  does not re-harvest the same reference activations.
+
+Features:
+
+- **Per-op-type alpha override** in the auto-alpha search (pin an op type to a
+  fixed alpha, or give it its own `min:max:step` grid).
+- **Per-layer alpha summary** logged after the search (histogram per op type plus
+  one line per smoothed node).
+- **Richer quantization statistics table**: fp32 ops are split into "quantizable"
+  (weight-bearing, the quantizer could convert them directly) versus "needs an
+  int8 input" (weightless/pass-through ops that only convert inside an int8
+  region), and the Reshape/Transpose glue rows are always shown.
+- tqdm progress bars over the alpha search and both calibration passes, and the
+  per-evaluation ORT warning spam is silenced.
+
+The changes are regression-tested from the model repo
+([`scripts/test_quantize-int8-smoothquant.py`](https://huggingface.co/Olicorne/parakeet-tdt-0.6b-v3-smoothquant-onnx/blob/main/scripts/test_quantize-int8-smoothquant.py)).
+This fork was developed with [Claude Code](https://claude.com/claude-code).
+The original upstream README follows.
+
+---
+
 Neural Compressor aims to provide popular model compression techniques inherited from [Intel Neural Compressor](https://github.com/intel/neural-compressor) yet focused on ONNX model quantization such as SmoothQuant, weight-only quantization through [ONNX Runtime](https://onnxruntime.ai/). In particular, the tool provides the key features, typical examples, and open collaborations as below:
 
 * Support a wide range of Intel hardware such as [Intel Xeon Scalable Processors](https://www.intel.com/content/www/us/en/products/details/processors/xeon/scalable.html) and AIPC

--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ Correctness:
 - **Auto-alpha search no longer runs on an exhausted dataloader.** Upstream's
   `alpha="auto"` consumed the calibration reader before the search, so every layer
   silently got `alpha_min`; the reader is now rewound and the per-node reference
-  activations are cached (also fixes the large-model path).
+  activations are cached (also fixes the large-model path). (commit [`d6745e4`](https://github.com/thiswillbeyourgithub/neural-compressor-fork/commit/d6745e4))
 - **The alpha grid includes both endpoints**: upstream's `np.arange` stopped one
-  step short of `alpha_max`, so the maximum alpha was never evaluated.
+  step short of `alpha_max`, so the maximum alpha was never evaluated. (commit [`8d88f45`](https://github.com/thiswillbeyourgithub/neural-compressor-fork/commit/8d88f45))
 - **The selected execution provider reaches the smoother calibration.** The
   smoother passed `execution_provider=` to the `Calibrator`, whose constructor
   parameter is `providers=`, so the argument fell into `**kwargs` and was
   silently dropped: every smoother-calibration forward ran on the
   `CPUExecutionProvider` even when the caller selected CUDA. The provider list is
-  now forwarded, so `--ep cuda` actually calibrates on the GPU.
+  now forwarded, so `--ep cuda` actually calibrates on the GPU. (commit [`ad8c01b`](https://github.com/thiswillbeyourgithub/neural-compressor-fork/commit/ad8c01b))
 
 Memory and speed:
 
@@ -42,10 +42,10 @@ Memory and speed:
   every dumped activation tensor of every calibration sample until the end of the
   loop (an in-code upstream TODO), so RAM grew linearly with samples x dumped
   tensors and large exports OOMed. Each sample is now folded straight into the
-  per-tensor histogram; peak RAM no longer depends on the sample count.
+  per-tensor histogram; peak RAM no longer depends on the sample count. (commit [`6f69d55`](https://github.com/thiswillbeyourgithub/neural-compressor-fork/commit/6f69d55))
 - **The auto-alpha QDQ sub-graph session is built once per node** (weights fed as
   runtime inputs), not once per (node, alpha) and originally once per calibration
-  sample; wide alpha grids no longer balloon ORT arena memory or rebuild time.
+  sample; wide alpha grids no longer balloon ORT arena memory or rebuild time. (commits [`594f6f9`](https://github.com/thiswillbeyourgithub/neural-compressor-fork/commit/594f6f9), [`f2a102f`](https://github.com/thiswillbeyourgithub/neural-compressor-fork/commit/f2a102f))
 - **Variable-length calibration windows are accepted.** That once-per-node QDQ
   sub-graph baked the FIRST sample's concrete activation shape into its input/output
   value_infos, so the cached session rejected any later calibration window of a
@@ -54,9 +54,9 @@ Memory and speed:
   input/output dims are now left dynamic (ORT resolves the real shape per `run()` from
   the fed array, so equal-length calibration is numerically unchanged), letting one
   calibration set mix short and long clips, e.g. per-language short utterances plus
-  full-length speeches.
+  full-length speeches. (commit [`0a22d36`](https://github.com/thiswillbeyourgithub/neural-compressor-fork/commit/0a22d36))
 - **Per-node activation caching across the alpha grid** so each alpha evaluation
-  does not re-harvest the same reference activations.
+  does not re-harvest the same reference activations. (commit [`d6745e4`](https://github.com/thiswillbeyourgithub/neural-compressor-fork/commit/d6745e4))
 - **The large-model alpha search never touches the model proto.** Each (node, alpha)
   evaluation used to rewrite the node's weight initializer twice (scale then recover),
   and even plain `numpy_helper.to_array` reads materialize external weights into the
@@ -65,7 +65,7 @@ Memory and speed:
   nodes x alphas and survived into static calibration: a 0.1-step grid OOMed a real
   encoder export where a 0.2-step grid fit. Candidate weights are now scaled in numpy
   and fed to the QDQ-loss session directly, and external weights are read via a
-  throwaway TensorProto, so the search retains nothing.
+  throwaway TensorProto, so the search retains nothing. (commit [`72de740`](https://github.com/thiswillbeyourgithub/neural-compressor-fork/commit/72de740))
 - **Memory-conservative calibration sessions.** The augmented dump graphs return
   hundreds of activation tensors per forward and ORT's BFC arenas grow ahead of
   demand (power-of-two extends) and never release, so the calibration sessions
@@ -74,7 +74,7 @@ Memory and speed:
   handful of forwards, so the allocator-speed trade is free:
   `conservative_session_resources()` disables the CPU arena and pins the CUDA
   arena to `kSameAsRequested` growth (with the heuristic cuDNN algo search),
-  applied to both the static-calibration session and the smoother's dump session.
+  applied to both the static-calibration session and the smoother's dump session. (commit [`6c6e0cf`](https://github.com/thiswillbeyourgithub/neural-compressor-fork/commit/6c6e0cf))
 - **Streaming per-channel percentile in the smoother calibration.** The smoother
   calibration stacked every collected sample's activations and called
   `np.percentile` once at the end, so RAM grew as samples x frames x channels
@@ -84,7 +84,7 @@ Memory and speed:
   folded into a per-channel running top-K reducer (`StreamingChannelPercentile`)
   and freed; the reducer reproduces `np.percentile` bit-for-bit (its float64
   promotion and `t >= 0.5` lerp branch included) and re-checks that K was large
-  enough for the actual row count, so a result can never be silently wrong.
+  enough for the actual row count, so a result can never be silently wrong. (commit [`e61fb24`](https://github.com/thiswillbeyourgithub/neural-compressor-fork/commit/e61fb24))
 - **Sliced static-calibration dump to bound VRAM.** Static int8 calibration
   augments the model so EVERY calibrated tensor becomes a graph output, and ORT
   keeps all graph outputs resident for the whole forward, so a long calibration
@@ -94,20 +94,20 @@ Memory and speed:
   are dumped in slices of that many graph outputs, each slice its own augment +
   forward over the same (rewound) windows, so only one slice is resident at a
   time; the per-tensor calibration ranges stay bit-identical to the single-pass
-  dump (it only trades extra forwards for a smaller peak).
+  dump (it only trades extra forwards for a smaller peak). (commit [`a495323`](https://github.com/thiswillbeyourgithub/neural-compressor-fork/commit/a495323))
 
 Features:
 
 - **Per-op-type alpha override** in the auto-alpha search (pin an op type to a
-  fixed alpha, or give it its own `min:max:step` grid).
+  fixed alpha, or give it its own `min:max:step` grid). (commit [`280b123`](https://github.com/thiswillbeyourgithub/neural-compressor-fork/commit/280b123))
 - **Per-layer alpha summary** logged after the search (histogram per op type plus
-  one line per smoothed node).
+  one line per smoothed node). (commit [`0a532e1`](https://github.com/thiswillbeyourgithub/neural-compressor-fork/commit/0a532e1))
 - **Sensitivity-based mixed precision** (`extra_options["SmoothQuantExcludeWorst"]`):
   the auto-alpha search records every smoothed node's best achievable QDQ loss,
   normalized by that node's reference-output energy so it is comparable across
   nodes (`Smoother.auto_alpha_losses`). Setting the option to an int n (or a
   fraction in (0, 1)) keeps the n worst-quantizing nodes out of quantization
-  entirely, trading a little file size for accuracy on the layers int8 hurts most.
+  entirely, trading a little file size for accuracy on the layers int8 hurts most. (commit [`89b4363`](https://github.com/thiswillbeyourgithub/neural-compressor-fork/commit/89b4363))
 - **Resumable, crash-safe exports.** Given a checkpoint directory
   (`extra_options["SmoothQuantCheckpointDir"]` plus
   `CalibParamsCheckpointFile`), the smoother persists its expensive intermediates
@@ -123,13 +123,13 @@ Features:
   its full run configuration and owns invalidation) but DO record the slice
   partition that produced the static-calibration partial, so a resume with a
   changed `CalibDumpBatch` or tensor set is discarded rather than applied to the
-  wrong slices.
+  wrong slices. (commits [`55a3c75`](https://github.com/thiswillbeyourgithub/neural-compressor-fork/commit/55a3c75), [`628f57f`](https://github.com/thiswillbeyourgithub/neural-compressor-fork/commit/628f57f), [`9eb2d4e`](https://github.com/thiswillbeyourgithub/neural-compressor-fork/commit/9eb2d4e), [`0c58d7b`](https://github.com/thiswillbeyourgithub/neural-compressor-fork/commit/0c58d7b))
 - **Richer quantization statistics table**: fp32 ops are split into "quantizable"
   (weight-bearing, the quantizer could convert them directly) versus "needs an
   int8 input" (weightless/pass-through ops that only convert inside an int8
-  region), and the Reshape/Transpose glue rows are always shown.
+  region), and the Reshape/Transpose glue rows are always shown. (commit [`e792411`](https://github.com/thiswillbeyourgithub/neural-compressor-fork/commit/e792411))
 - tqdm progress bars over the alpha search and both calibration passes, and the
-  per-evaluation ORT warning spam is silenced.
+  per-evaluation ORT warning spam is silenced. (commits [`82e3451`](https://github.com/thiswillbeyourgithub/neural-compressor-fork/commit/82e3451), [`9f0e94b`](https://github.com/thiswillbeyourgithub/neural-compressor-fork/commit/9f0e94b))
 
 The changes are regression-tested from the model repo
 ([`scripts/test_quantize-int8-smoothquant.py`](https://huggingface.co/Olicorne/parakeet-tdt-0.6b-v3-smoothquant-onnx/blob/main/scripts/test_quantize-int8-smoothquant.py)).

--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ Memory and speed:
 - **The auto-alpha QDQ sub-graph session is built once per node** (weights fed as
   runtime inputs), not once per (node, alpha) and originally once per calibration
   sample; wide alpha grids no longer balloon ORT arena memory or rebuild time.
+- **Variable-length calibration windows are accepted.** That once-per-node QDQ
+  sub-graph baked the FIRST sample's concrete activation shape into its input/output
+  value_infos, so the cached session rejected any later calibration window of a
+  different sequence length (`Got invalid dimensions for input ... Got: N Expected:
+  M`). Calibration was silently constrained to uniformly-sized windows. The activation
+  input/output dims are now left dynamic (ORT resolves the real shape per `run()` from
+  the fed array, so equal-length calibration is numerically unchanged), letting one
+  calibration set mix short and long clips, e.g. per-language short utterances plus
+  full-length speeches.
 - **Per-node activation caching across the alpha grid** so each alpha evaluation
   does not re-harvest the same reference activations.
 - **The large-model alpha search never touches the model proto.** Each (node, alpha)

--- a/onnx_neural_compressor/algorithms/post_training_quant/calibrate.py
+++ b/onnx_neural_compressor/algorithms/post_training_quant/calibrate.py
@@ -233,11 +233,12 @@ class ONNXRTAugment:
             if self.execution_provider != "TensorrtExecutionProvider"
             else "CUDAExecutionProvider"
         )
+        providers = quant_utils.conservative_session_resources(so, [execution_provider])
         session = (
-            onnxruntime.InferenceSession(self.augmented_model.SerializeToString(), so, providers=[execution_provider])
+            onnxruntime.InferenceSession(self.augmented_model.SerializeToString(), so, providers=providers)
             if not self.model_wrapper.is_large_model
             else onnxruntime.InferenceSession(
-                self.model_wrapper.model_path + "_augment.onnx", so, providers=[execution_provider]
+                self.model_wrapper.model_path + "_augment.onnx", so, providers=providers
             )
         )
 

--- a/onnx_neural_compressor/algorithms/post_training_quant/calibrate.py
+++ b/onnx_neural_compressor/algorithms/post_training_quant/calibrate.py
@@ -296,22 +296,37 @@ class ONNXRTAugment:
         # all earlier slices are complete. A pre-batching checkpoint has no "batch" key
         # and reads as slice 0 (the single-pass case is exactly slice 0 of 1).
         partial_path = str(self.checkpoint_file) + ".partial" if self.checkpoint_file else None
+        # The (slice, samples) restore point is meaningful ONLY against the partition that
+        # produced it: a changed dump_batch_size (or calibrated tensor set) re-slices the
+        # dump, so the same slice index then spans different tensors and resuming would
+        # skip the wrong ones, silently leaving tensors uncalibrated. Key the partial by
+        # its partition and discard one that does not match (this also drops pre-partition
+        # checkpoints, which carry no signature) rather than resume it into wrong ranges.
+        partition_sig = [None if b is None else list(b) for b in batches]
         restored_batch, restored_collected = 0, 0
         if partial_path and os.path.exists(partial_path):
+            discard = None
             try:
                 with open(partial_path, "rb") as f:
                     partial = pickle.load(f)
-                restored_batch = int(partial.get("batch", 0))
-                restored_collected = int(partial["collected"])
-                name_to_calibrator = partial["name_to_calibrator"]
-                activation_tensors_calib_range = partial["activation_tensors_calib_range"]
+                if partial.get("partition") != partition_sig:
+                    discard = ("dumped for a different slice partition: dump_batch_size or "
+                               "the calibrated tensor set changed")
+                else:
+                    restored_batch = int(partial.get("batch", 0))
+                    restored_collected = int(partial["collected"])
+                    name_to_calibrator = partial["name_to_calibrator"]
+                    activation_tensors_calib_range = partial["activation_tensors_calib_range"]
+            except Exception as e:
+                discard = "unreadable ({})".format(e)
+            if discard is None:
                 logger.info(
                     "Resuming activation calibration from {} (slice {}, {} samples already collected)".format(
                         partial_path, restored_batch, restored_collected
                     )
                 )
-            except Exception as e:
-                logger.warning("Discarding unreadable calibration checkpoint {} ({})".format(partial_path, e))
+            else:
+                logger.warning("Discarding stale calibration checkpoint {} ({})".format(partial_path, discard))
                 restored_batch, restored_collected = 0, 0
                 name_to_calibrator = {}
                 activation_tensors_calib_range = {}
@@ -323,6 +338,7 @@ class ONNXRTAugment:
             with open(tmp_path, "wb") as f:
                 pickle.dump(
                     {
+                        "partition": partition_sig,
                         "batch": state["batch"],
                         "collected": state["collected"],
                         "name_to_calibrator": name_to_calibrator,

--- a/onnx_neural_compressor/algorithms/post_training_quant/calibrate.py
+++ b/onnx_neural_compressor/algorithms/post_training_quant/calibrate.py
@@ -268,7 +268,6 @@ class ONNXRTAugment:
             name_to_node[data_name] = node.name
 
         activation_tensors_calib_range = {}
-        intermediate_tensor = {}
         name_to_calibrator = {}
         ort_inputs_for_next_split_model = []
 
@@ -287,16 +286,22 @@ class ONNXRTAugment:
                     else:
                         _calibrator = name_to_calibrator[node_output_names[output_idx]]
 
-                    # currently, the calibration range for each iteration is collected if
-                    # the calibration method is minmax, otherwise the tensor data is collected.
-                    # TODO: for entropy and percentile method, need to support range collection
-                    # per iteration in the future.
+                    # Every calibration method collects per iteration: MinMax keeps a
+                    # running range, Entropy/Percentile fold each sample into their
+                    # incremental histogram (HistogramCollector.combine_histogram).
+                    # Upstream instead buffered EVERY dumped tensor of EVERY sample for
+                    # Entropy/Percentile until the end of the loop (an explicit upstream
+                    # TODO), which made RAM grow linearly with the number of calibration
+                    # samples and OOMed large dump sets.
                     if _calibrator.method_name == "MinMax":
                         _calibrator.collect(output)
                         activation_tensors_calib_range[node_output_names[output_idx]] = [list(_calibrator.calib_range)]
                         name_to_calibrator[node_output_names[output_idx]] = _calibrator
                     else:
-                        intermediate_tensor.setdefault((node_output_names[output_idx], node_name), []).append(output)
+                        if output.dtype in [bool]:  # output type of some ops is bool, skip
+                            continue
+                        _calibrator.collect(output)
+                        name_to_calibrator[node_output_names[output_idx]] = _calibrator
                 elif q_config is None:
                     activation_tensors_calib_range.setdefault(node_output_names[output_idx], []).append(output)
 
@@ -314,19 +319,13 @@ class ONNXRTAugment:
                 _collect_data(inputs)
             idx += 1
 
-        # for entropy and percentile method, collect calibration range after all tensors are collected.
-        merged_dict = intermediate_tensor
-        for (output_name, node_name), datas in merged_dict.items():
-            if any([data is None for data in datas]):
+        # for entropy and percentile method, every sample is already merged into the
+        # per-tensor histogram; just read out the final calibration ranges.
+        for output_name, _calibrator in name_to_calibrator.items():
+            if _calibrator.method_name == "MinMax":
                 continue
-            if any([data.dtype in [bool] for data in datas]):  # output type of some ops is bool, skip
-                continue
-            calib_method = q_config[node_name]["calibrate_method"] if q_config and node_name in q_config else 0
-            _calibrator = calibrator.CALIBRATOR[calib_method]()
-            _calibrator.collect(datas)
             activation_tensors_calib_range.setdefault(output_name, []).append(list(_calibrator.calib_range))
             _calibrator.clear()
-            del _calibrator
 
         return activation_tensors_calib_range
 

--- a/onnx_neural_compressor/algorithms/post_training_quant/calibrate.py
+++ b/onnx_neural_compressor/algorithms/post_training_quant/calibrate.py
@@ -22,7 +22,9 @@
 import copy
 import logging
 import os
+import pickle
 import sys
+import time
 from importlib import util
 
 import numpy as np
@@ -54,6 +56,8 @@ class ONNXRTAugment:
         iterations=[],
         execution_provider="CPUExecutionProvider",
         reduce_range=False,
+        checkpoint_file=None,
+        checkpoint_interval_sec=1200,
         **kwargs,
     ):
         """Initialization.
@@ -67,6 +71,14 @@ class ONNXRTAugment:
             iterations (list, optional): tensor of which iteration will be collected. Defaults to [].
             execution_provider (list, optional): execution provider for onnxruntime. Defaults to 'CPUExecutionProvider'.
             reduce_range (bool, optional): use 7 bit or not. Defaults to False.
+            checkpoint_file (str, optional): when set, the activation-calibration loop
+                periodically pickles its streaming per-tensor calibrator state to
+                <checkpoint_file>.partial and skips already-consumed samples on the next
+                run, so a run killed MID-calibration resumes instead of redoing every
+                forward. The caller keys the file by its configuration and removes the
+                partial once the final params are saved.
+            checkpoint_interval_sec (float, optional): minimum seconds between those
+                state dumps (0 dumps after every sample). Defaults to 1200 (20 minutes).
         """
         self.model_wrapper = (
             model_wrapper
@@ -89,6 +101,8 @@ class ONNXRTAugment:
         self.dynamically_quantized = False
         self.ort_version = version.Version(onnxruntime.__version__)
         self.reduce_range = reduce_range
+        self.checkpoint_file = checkpoint_file
+        self.checkpoint_interval_sec = checkpoint_interval_sec
 
     def augment_graph(self):
         """Augment_graph.
@@ -272,6 +286,30 @@ class ONNXRTAugment:
         name_to_calibrator = {}
         ort_inputs_for_next_split_model = []
 
+        # Every calibration method streams per sample (running MinMax range or
+        # incremental histogram), so the whole loop state fits in a small pickle.
+        # When a checkpoint file is configured, restore that state and skip the
+        # forwards whose contribution it already contains.
+        partial_path = str(self.checkpoint_file) + ".partial" if self.checkpoint_file else None
+        restored = 0
+        if partial_path and os.path.exists(partial_path):
+            try:
+                with open(partial_path, "rb") as f:
+                    partial = pickle.load(f)
+                restored = int(partial["collected"])
+                name_to_calibrator = partial["name_to_calibrator"]
+                activation_tensors_calib_range = partial["activation_tensors_calib_range"]
+                logger.info(
+                    "Resuming activation calibration from {} ({} samples already collected)".format(
+                        partial_path, restored
+                    )
+                )
+            except Exception as e:
+                logger.warning("Discarding unreadable calibration checkpoint {} ({})".format(partial_path, e))
+                restored = 0
+                name_to_calibrator = {}
+                activation_tensors_calib_range = {}
+
         def _collect_data(inputs):
             for output_idx, output in enumerate(session.run(None, inputs)):
                 if q_config is not None and output.size != 0:
@@ -306,6 +344,32 @@ class ONNXRTAugment:
                 elif q_config is None:
                     activation_tensors_calib_range.setdefault(node_output_names[output_idx], []).append(output)
 
+        state = {"collected": 0, "last_flush": time.time()}
+
+        def _flush_partial():
+            tmp_path = partial_path + ".tmp"
+            with open(tmp_path, "wb") as f:
+                pickle.dump(
+                    {
+                        "collected": state["collected"],
+                        "name_to_calibrator": name_to_calibrator,
+                        "activation_tensors_calib_range": activation_tensors_calib_range,
+                    },
+                    f,
+                )
+            os.replace(tmp_path, partial_path)
+            state["last_flush"] = time.time()
+
+        def _consume(inputs):
+            if state["collected"] < restored:
+                # this sample's contribution is already inside the restored state
+                state["collected"] += 1
+                return
+            _collect_data(inputs)
+            state["collected"] += 1
+            if partial_path and time.time() - state["last_flush"] >= self.checkpoint_interval_sec:
+                _flush_partial()
+
         idx = 0
         while True:
             inputs = self.dataloader.get_next()
@@ -315,9 +379,9 @@ class ONNXRTAugment:
                 if idx > max(self.iterations):
                     break
                 if idx in self.iterations:
-                    _collect_data(inputs)
+                    _consume(inputs)
             else:
-                _collect_data(inputs)
+                _consume(inputs)
             idx += 1
 
         # for entropy and percentile method, every sample is already merged into the

--- a/onnx_neural_compressor/algorithms/post_training_quant/calibrate.py
+++ b/onnx_neural_compressor/algorithms/post_training_quant/calibrate.py
@@ -30,6 +30,7 @@ from importlib import util
 import numpy as np
 import onnx
 import onnxruntime
+import tqdm
 from packaging import version
 
 from onnx_neural_compressor import logger, onnx_model
@@ -58,6 +59,7 @@ class ONNXRTAugment:
         reduce_range=False,
         checkpoint_file=None,
         checkpoint_interval_sec=1200,
+        dump_batch_size=0,
         **kwargs,
     ):
         """Initialization.
@@ -79,6 +81,16 @@ class ONNXRTAugment:
                 partial once the final params are saved.
             checkpoint_interval_sec (float, optional): minimum seconds between those
                 state dumps (0 dumps after every sample). Defaults to 1200 (20 minutes).
+            dump_batch_size (int, optional): when > 0, dump the calibrated activation
+                tensors in slices of this many per augmented forward pass instead of
+                exposing them all as graph outputs at once. ORT keeps every graph
+                output resident for the whole forward, so a single long-sequence
+                window can peak past GPU VRAM; slicing bounds the peak to one slice's
+                activations at the cost of re-forwarding the dataloader once per slice.
+                Each tensor is still calibrated over the same windows, so the per-tensor
+                range is identical to the single-pass result. Defaults to 0 (dump all at
+                once, the original behaviour). Ignored for the DequantizeLinear-augmented
+                / already-quantized inspection paths.
         """
         self.model_wrapper = (
             model_wrapper
@@ -103,16 +115,20 @@ class ONNXRTAugment:
         self.reduce_range = reduce_range
         self.checkpoint_file = checkpoint_file
         self.checkpoint_interval_sec = checkpoint_interval_sec
+        self.dump_batch_size = dump_batch_size
 
-    def augment_graph(self):
+    def augment_graph(self, tensor_filter=None):
         """Augment_graph.
 
         Adds nodes to all quantization_candidates op type nodes in model and
         ensures their outputs are stored as part of the graph output.
 
         Args:
-            activation_only (bool, optional): whether to dump activation tensor only. Defaults to False.
-            weight_only (bool, optional): whether to dump weight_only. Defaults to False.
+            tensor_filter (set, optional): when given, only tensors in this set are
+                exposed as graph outputs (the rest are skipped). Lets the caller dump
+                the calibrated tensors in slices across several smaller augmented
+                graphs to bound ORT's peak memory. None (default) dumps every
+                calibrated tensor, the original behaviour.
         """
         self.dequantized_output.clear()
         onnx_version = version.Version(onnx.__version__)
@@ -168,6 +184,8 @@ class ONNXRTAugment:
         model_inputs = [i.name for i in model.graph.input]
         for tensor in tensors_to_dump:
             if tensor not in node_outputs and tensor not in model_inputs:
+                continue
+            if tensor_filter is not None and tensor not in tensor_filter:
                 continue
             if self.augment_nodes:
                 for augment_node_type in self.augment_nodes:
@@ -236,121 +254,76 @@ class ONNXRTAugment:
         Returns:
             dict: calib ranges
         """
-        # conduct inference session and get intermediate outputs
-        so = onnxruntime.SessionOptions()
-        so.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_DISABLE_ALL
-        if sys.version_info < (3, 11) and util.find_spec("onnxruntime_extensions"):
-            so.register_custom_ops_library(onnxruntime_extensions.get_library_path())
-
-        execution_provider = (
-            self.execution_provider
-            if self.execution_provider != "TensorrtExecutionProvider"
-            else "CUDAExecutionProvider"
+        # The augmented dump graph exposes every calibrated tensor as a graph OUTPUT,
+        # and ORT keeps every graph output resident for the whole forward, so one
+        # long-sequence window's activations all peak at once and can exceed GPU VRAM.
+        # When dump_batch_size > 0 the calibrated tensors are dumped in slices: each
+        # slice gets its own augment + forward pass (the dataloader is rewound between
+        # passes), so only one slice's outputs are retained at a time. Each tensor is
+        # still calibrated over the SAME windows, so its per-tensor range is identical
+        # to the single-pass result; dump_batch_size only trades extra forwards for a
+        # smaller peak. Batching needs plain-tensor outputs addressable by name, so it
+        # is off for the DequantizeLinear-augmented / already-quantized inspect paths.
+        batched = bool(
+            self.dump_batch_size
+            and self.dump_batch_size > 0
+            and not self.augment_nodes
+            and not self.already_quantized
         )
-        providers = quant_utils.conservative_session_resources(so, [execution_provider])
-        session = (
-            onnxruntime.InferenceSession(self.augmented_model.SerializeToString(), so, providers=providers)
-            if not self.model_wrapper.is_large_model
-            else onnxruntime.InferenceSession(
-                self.model_wrapper.model_path + "_augment.onnx", so, providers=providers
-            )
-        )
-
-        len_inputs = len(session.get_inputs())
-        inputs_names = [session.get_inputs()[i].name for i in range(len_inputs)]
-        len_outputs = len(session.get_outputs())
-        outputs_names = [session.get_outputs()[i].name for i in range(len_outputs)]
-
-        node_output_names = [
-            output.name if output.name not in self.dequantized_output else self.dequantized_output[output.name]
-            for output in session.get_outputs()
-        ]
-        augment_model_wrapper = (
-            onnx_model.ONNXModel(self.augmented_model, load_external_data=False)
-            if not self.model_wrapper.is_large_model
-            else onnx_model.ONNXModel(self.model_wrapper.model_path + "_augment.onnx", load_external_data=False)
-        )
-        input_name_to_nodes = augment_model_wrapper.input_name_to_nodes()
-        output_name_to_node = augment_model_wrapper.output_name_to_node()
-        name_to_node = {}
-        for data_name in node_output_names:
-            node = None
-            if data_name in output_name_to_node:
-                node = output_name_to_node[data_name]
-            elif data_name in input_name_to_nodes:
-                node = input_name_to_nodes[data_name][0]
-            assert node, "{} is neither an input nor an output of nodes in augmented model.".format(data_name)
-            name_to_node[data_name] = node.name
+        if batched:
+            # Full augment once, only to enumerate the calibrated tensor set (no session
+            # is built here, so no GPU cost); then re-augment per slice. Reuses
+            # augment_graph rather than duplicating its tensor-selection logic. Every
+            # calibrated tensor is exposed as a graph output, so the augmented outputs ARE
+            # that set (this includes the model's own outputs, which a per-slice augment
+            # cannot drop and which _collect_data therefore calibrates only in their
+            # owning slice, see slice_owned below).
+            self.augment_graph()
+            dump_names = sorted(o.name for o in self.augmented_model.graph.output)
+            batches = [
+                dump_names[i : i + self.dump_batch_size]
+                for i in range(0, len(dump_names), self.dump_batch_size)
+            ] or [[]]
+        else:
+            batches = [None]
 
         activation_tensors_calib_range = {}
         name_to_calibrator = {}
-        ort_inputs_for_next_split_model = []
 
-        # Every calibration method streams per sample (running MinMax range or
-        # incremental histogram), so the whole loop state fits in a small pickle.
-        # When a checkpoint file is configured, restore that state and skip the
-        # forwards whose contribution it already contains.
+        # Mid-pass checkpoint: every calibration method streams per sample (running
+        # MinMax range or incremental histogram), so the loop state is a small pickle.
+        # The restore point is (slice index, samples already folded into that slice);
+        # all earlier slices are complete. A pre-batching checkpoint has no "batch" key
+        # and reads as slice 0 (the single-pass case is exactly slice 0 of 1).
         partial_path = str(self.checkpoint_file) + ".partial" if self.checkpoint_file else None
-        restored = 0
+        restored_batch, restored_collected = 0, 0
         if partial_path and os.path.exists(partial_path):
             try:
                 with open(partial_path, "rb") as f:
                     partial = pickle.load(f)
-                restored = int(partial["collected"])
+                restored_batch = int(partial.get("batch", 0))
+                restored_collected = int(partial["collected"])
                 name_to_calibrator = partial["name_to_calibrator"]
                 activation_tensors_calib_range = partial["activation_tensors_calib_range"]
                 logger.info(
-                    "Resuming activation calibration from {} ({} samples already collected)".format(
-                        partial_path, restored
+                    "Resuming activation calibration from {} (slice {}, {} samples already collected)".format(
+                        partial_path, restored_batch, restored_collected
                     )
                 )
             except Exception as e:
                 logger.warning("Discarding unreadable calibration checkpoint {} ({})".format(partial_path, e))
-                restored = 0
+                restored_batch, restored_collected = 0, 0
                 name_to_calibrator = {}
                 activation_tensors_calib_range = {}
 
-        def _collect_data(inputs):
-            for output_idx, output in enumerate(session.run(None, inputs)):
-                if q_config is not None and output.size != 0:
-                    node_name = name_to_node[node_output_names[output_idx]]
-                    if node_output_names[output_idx] not in name_to_calibrator:
-                        calib_method = (
-                            q_config[node_name]["calibrate_method"] if q_config and node_name in q_config else "MinMax"
-                        )
-                        assert calib_method in calibrator.CALIBRATOR, "Calibration method {} is not registered.".format(
-                            calib_method
-                        )
-                        _calibrator = calibrator.CALIBRATOR[calib_method]()
-                    else:
-                        _calibrator = name_to_calibrator[node_output_names[output_idx]]
-
-                    # Every calibration method collects per iteration: MinMax keeps a
-                    # running range, Entropy/Percentile fold each sample into their
-                    # incremental histogram (HistogramCollector.combine_histogram).
-                    # Upstream instead buffered EVERY dumped tensor of EVERY sample for
-                    # Entropy/Percentile until the end of the loop (an explicit upstream
-                    # TODO), which made RAM grow linearly with the number of calibration
-                    # samples and OOMed large dump sets.
-                    if _calibrator.method_name == "MinMax":
-                        _calibrator.collect(output)
-                        activation_tensors_calib_range[node_output_names[output_idx]] = [list(_calibrator.calib_range)]
-                        name_to_calibrator[node_output_names[output_idx]] = _calibrator
-                    else:
-                        if output.dtype in [bool]:  # output type of some ops is bool, skip
-                            continue
-                        _calibrator.collect(output)
-                        name_to_calibrator[node_output_names[output_idx]] = _calibrator
-                elif q_config is None:
-                    activation_tensors_calib_range.setdefault(node_output_names[output_idx], []).append(output)
-
-        state = {"collected": 0, "last_flush": time.time()}
+        state = {"batch": 0, "collected": 0, "last_flush": time.time()}
 
         def _flush_partial():
             tmp_path = partial_path + ".tmp"
             with open(tmp_path, "wb") as f:
                 pickle.dump(
                     {
+                        "batch": state["batch"],
                         "collected": state["collected"],
                         "name_to_calibrator": name_to_calibrator,
                         "activation_tensors_calib_range": activation_tensors_calib_range,
@@ -360,29 +333,136 @@ class ONNXRTAugment:
             os.replace(tmp_path, partial_path)
             state["last_flush"] = time.time()
 
-        def _consume(inputs):
-            if state["collected"] < restored:
-                # this sample's contribution is already inside the restored state
-                state["collected"] += 1
-                return
-            _collect_data(inputs)
-            state["collected"] += 1
-            if partial_path and time.time() - state["last_flush"] >= self.checkpoint_interval_sec:
-                _flush_partial()
+        total_iters = (max(self.iterations) + 1) if self.iterations else None
+        for batch_idx, batch in enumerate(batches):
+            if batch_idx < restored_batch:
+                # this whole slice's contribution is already inside the restored state
+                continue
+            # (re)augment for this slice; the unbatched path (batch is None) augments
+            # every calibrated tensor exactly once, reproducing the original behaviour.
+            self.augment_graph(tensor_filter=set(batch) if batch is not None else None)
+            # The model's own graph outputs stay exposed in every slice's session (a
+            # per-slice augment cannot remove a model output), so restrict calibration to
+            # the tensors this slice owns; the rest are dumped in their own slice. None
+            # (unbatched) calibrates every session output, as before.
+            slice_owned = set(batch) if batch is not None else None
 
-        idx = 0
-        while True:
-            inputs = self.dataloader.get_next()
-            if not inputs:
-                break
-            if self.iterations != []:
-                if idx > max(self.iterations):
+            # conduct inference session and get intermediate outputs
+            so = onnxruntime.SessionOptions()
+            so.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_DISABLE_ALL
+            if sys.version_info < (3, 11) and util.find_spec("onnxruntime_extensions"):
+                so.register_custom_ops_library(onnxruntime_extensions.get_library_path())
+            execution_provider = (
+                self.execution_provider
+                if self.execution_provider != "TensorrtExecutionProvider"
+                else "CUDAExecutionProvider"
+            )
+            providers = quant_utils.conservative_session_resources(so, [execution_provider])
+            session = (
+                onnxruntime.InferenceSession(self.augmented_model.SerializeToString(), so, providers=providers)
+                if not self.model_wrapper.is_large_model
+                else onnxruntime.InferenceSession(
+                    self.model_wrapper.model_path + "_augment.onnx", so, providers=providers
+                )
+            )
+
+            node_output_names = [
+                output.name if output.name not in self.dequantized_output else self.dequantized_output[output.name]
+                for output in session.get_outputs()
+            ]
+            augment_model_wrapper = (
+                onnx_model.ONNXModel(self.augmented_model, load_external_data=False)
+                if not self.model_wrapper.is_large_model
+                else onnx_model.ONNXModel(self.model_wrapper.model_path + "_augment.onnx", load_external_data=False)
+            )
+            input_name_to_nodes = augment_model_wrapper.input_name_to_nodes()
+            output_name_to_node = augment_model_wrapper.output_name_to_node()
+            name_to_node = {}
+            for data_name in node_output_names:
+                node = None
+                if data_name in output_name_to_node:
+                    node = output_name_to_node[data_name]
+                elif data_name in input_name_to_nodes:
+                    node = input_name_to_nodes[data_name][0]
+                assert node, "{} is neither an input nor an output of nodes in augmented model.".format(data_name)
+                name_to_node[data_name] = node.name
+
+            def _collect_data(inputs):
+                for output_idx, output in enumerate(session.run(None, inputs)):
+                    if slice_owned is not None and node_output_names[output_idx] not in slice_owned:
+                        continue  # belongs to another slice; calibrated there, not here
+                    if q_config is not None and output.size != 0:
+                        node_name = name_to_node[node_output_names[output_idx]]
+                        if node_output_names[output_idx] not in name_to_calibrator:
+                            calib_method = (
+                                q_config[node_name]["calibrate_method"]
+                                if q_config and node_name in q_config
+                                else "MinMax"
+                            )
+                            assert (
+                                calib_method in calibrator.CALIBRATOR
+                            ), "Calibration method {} is not registered.".format(calib_method)
+                            _calibrator = calibrator.CALIBRATOR[calib_method]()
+                        else:
+                            _calibrator = name_to_calibrator[node_output_names[output_idx]]
+
+                        # Every calibration method collects per iteration: MinMax keeps a
+                        # running range, Entropy/Percentile fold each sample into their
+                        # incremental histogram (HistogramCollector.combine_histogram).
+                        # Upstream instead buffered EVERY dumped tensor of EVERY sample for
+                        # Entropy/Percentile until the end of the loop (an explicit upstream
+                        # TODO), which made RAM grow linearly with the number of calibration
+                        # samples and OOMed large dump sets.
+                        if _calibrator.method_name == "MinMax":
+                            _calibrator.collect(output)
+                            activation_tensors_calib_range[node_output_names[output_idx]] = [
+                                list(_calibrator.calib_range)
+                            ]
+                            name_to_calibrator[node_output_names[output_idx]] = _calibrator
+                        else:
+                            if output.dtype in [bool]:  # output type of some ops is bool, skip
+                                continue
+                            _calibrator.collect(output)
+                            name_to_calibrator[node_output_names[output_idx]] = _calibrator
+                    elif q_config is None:
+                        activation_tensors_calib_range.setdefault(node_output_names[output_idx], []).append(output)
+
+            state["batch"] = batch_idx
+            state["collected"] = 0
+            skip_in_batch = restored_collected if batch_idx == restored_batch else 0
+
+            def _consume(inputs):
+                if state["collected"] < skip_in_batch:
+                    # this sample's contribution is already inside the restored state
+                    state["collected"] += 1
+                    return
+                _collect_data(inputs)
+                state["collected"] += 1
+                if partial_path and time.time() - state["last_flush"] >= self.checkpoint_interval_sec:
+                    _flush_partial()
+
+            # This per-sample forward pass is the slow, otherwise silent static-int8
+            # calibration phase; show its progress (one bar per slice when batched).
+            desc = "static int8 calibration"
+            if batched:
+                desc += " (slice {}/{})".format(batch_idx + 1, len(batches))
+            pbar = tqdm.tqdm(total=total_iters, desc=desc, unit="sample", leave=False)
+            self.dataloader.rewind()
+            idx = 0
+            while True:
+                inputs = self.dataloader.get_next()
+                if not inputs:
                     break
-                if idx in self.iterations:
+                if self.iterations != []:
+                    if idx > max(self.iterations):
+                        break
+                    if idx in self.iterations:
+                        _consume(inputs)
+                else:
                     _consume(inputs)
-            else:
-                _consume(inputs)
-            idx += 1
+                idx += 1
+                pbar.update(1)
+            pbar.close()
 
         # for entropy and percentile method, every sample is already merged into the
         # per-tensor histogram; just read out the final calibration ranges.
@@ -573,11 +653,13 @@ class ONNXRTAugment:
     def dump_minmax(self, q_config):
         """Get calib ranges of tensors."""
         # pipeline of getting calib ranges of tensors during calibration:
-        # 1. augment_graph(): insert activation tensors to model output
-        # 2. get_intermediate_outputs():
-        #   2.1 get_activation_tensors_calib_range(): get calib ranges of activation tensors using the augment graph
-        #   2.2 get_weight_tensors_calib_range(): get calib ranges of weight tensors
-        self.augment_graph()
+        # 1. get_intermediate_outputs():
+        #   1.1 get_activation_tensors_calib_range(): augment the graph (all calibrated
+        #       tensors at once, or one slice at a time when dump_batch_size > 0) and
+        #       read each tensor's calib range off the augmented dump session(s)
+        #   1.2 get_weight_tensors_calib_range(): get calib ranges of weight tensors
+        # augment_graph() is owned by get_activation_tensors_calib_range now, because the
+        # batched path re-augments per slice; calling it here too would double-augment.
         node_output_names, output_dicts = self.get_intermediate_outputs(q_config)
         return self._map_calibration(node_output_names, output_dicts)
 

--- a/onnx_neural_compressor/algorithms/smoother/calibrator.py
+++ b/onnx_neural_compressor/algorithms/smoother/calibrator.py
@@ -25,6 +25,7 @@ import onnxruntime
 import tqdm
 
 from onnx_neural_compressor import data_reader, logger, onnx_model, utility
+from onnx_neural_compressor.algorithms import utility as quant_utils
 
 
 class Calibrator:
@@ -145,6 +146,7 @@ class Calibrator:
             so.register_custom_ops_library(get_library_path())
 
         providers = self.providers if "TensorrtExecutionProvider" not in self.providers else ["CUDAExecutionProvider"]
+        providers = quant_utils.conservative_session_resources(so, providers)
         if self.model_wrapper.is_large_model:  # pragma: no cover
             with tempfile.TemporaryDirectory(prefix="ort.calib.") as tmp_dir:
                 onnx.save_model(

--- a/onnx_neural_compressor/algorithms/smoother/calibrator.py
+++ b/onnx_neural_compressor/algorithms/smoother/calibrator.py
@@ -22,6 +22,7 @@ from typing import List
 import numpy as np
 import onnx
 import onnxruntime
+import tqdm
 
 from onnx_neural_compressor import data_reader, logger, onnx_model, utility
 
@@ -182,6 +183,11 @@ class Calibrator:
             for output_idx, output in enumerate(session.run(None, ort_inputs)):
                 output_dicts.setdefault(node_output_names[output_idx], []).append(output)
 
+        # This per-sample forward pass over the calibration set is the slow, otherwise
+        # silent phase logged as "Start smooth model calibration"; show its progress.
+        total = (max(self.iterations) + 1) if self.iterations else None
+        pbar = tqdm.tqdm(total=total, desc="SmoothQuant: collecting calibration activations",
+                         unit="sample", leave=False)
         idx = 0
         while True:
             inputs = self.dataloader.get_next()
@@ -195,6 +201,8 @@ class Calibrator:
             else:
                 _collect_data(inputs)
             idx += 1
+            pbar.update(1)
+        pbar.close()
         return output_dicts
 
     def calib_smooth(self, op_types, percentile: float = 99.999):

--- a/onnx_neural_compressor/algorithms/smoother/calibrator.py
+++ b/onnx_neural_compressor/algorithms/smoother/calibrator.py
@@ -15,6 +15,7 @@
 
 import importlib.util
 import json
+import math
 import os
 import pathlib
 import shutil
@@ -32,63 +33,189 @@ from onnx_neural_compressor import data_reader, logger, onnx_model, utility
 from onnx_neural_compressor.algorithms import utility as quant_utils
 
 
-def _acts_dir(checkpoint_dir):
-    return pathlib.Path(checkpoint_dir) / "smooth-acts"
+STREAM_STATE_FILE = "smooth-stream.npz"
 
 
-def clear_acts_checkpoint(checkpoint_dir):
-    """Remove the partial per-sample activation dumps. Called once the FULL smooth-calib
-    checkpoint exists (the per-sample files are superseded, and they are the bulky part:
-    every smoothed tensor's activation for every collected sample)."""
-    shutil.rmtree(_acts_dir(checkpoint_dir), ignore_errors=True)
+def clear_stream_checkpoint(checkpoint_dir):
+    """Remove the mid-pass calibration state. Called once the FULL smooth-calib
+    checkpoint exists (which supersedes it). Also removes the smooth-acts/ directory
+    a pre-streaming version of this code may have left behind (it dumped raw
+    per-sample activations there; the streaming reducer made that obsolete)."""
+    try:
+        os.remove(pathlib.Path(checkpoint_dir) / STREAM_STATE_FILE)
+    except FileNotFoundError:
+        pass
+    shutil.rmtree(pathlib.Path(checkpoint_dir) / "smooth-acts", ignore_errors=True)
 
 
-def load_acts_checkpoint(checkpoint_dir, keys):
-    """Restore the per-sample activation dumps of an interrupted calibration pass.
+class StreamingChannelPercentile:
+    """Exact streaming replacement for the hold-everything per-channel percentile.
 
-    Returns a list of {tensor_name: array} dicts for the contiguous samples 0..k-1
-    found in <checkpoint_dir>/smooth-acts/. The dumped tensor set must match `keys`
-    exactly (same op_types config); on mismatch the stale dump is deleted and []
-    returned, so a changed configuration can never half-resume into wrong numerics."""
-    d = _acts_dir(checkpoint_dir)
-    names_file = d / "names.json"
-    if not names_file.exists():
-        return []
-    with open(names_file) as f:
-        names = json.load(f)
-    if names != list(keys):
-        logger.warning(
-            "smooth-acts checkpoint in {} was dumped for a different tensor set; discarding it".format(d)
-        )
-        clear_acts_checkpoint(checkpoint_dir)
-        return []
-    samples = []
-    while True:
-        f = d / "sample-{:05d}.npz".format(len(samples))
-        if not f.exists():
-            break
-        with np.load(f) as z:
-            samples.append({n: z["arr_{}".format(j)] for j, n in enumerate(names)})
-    return samples
+    The smoother needs, per smoothed tensor, the per-channel {percentile} of
+    |activations| over every calibration sample. Upstream stacked every sample in
+    RAM and called np.percentile once at the end, so memory grew as
+    samples x frames x channels (~6 GB per 395 s window on the 0.6B encoder,
+    hundreds of GB per export). But for the high percentiles SmoothQuant uses
+    (99.999 by default) the answer only depends on the few largest values per
+    channel: np.percentile's linear interpolation reads the two order statistics
+    around rank (n-1)*q/100, which sit within the top ceil((n-1)*(1-q/100))+1
+    values. So this keeps a per-channel running top-K plus the exact row count n,
+    folds each sample in as it is collected (which can then be freed), and
+    reproduces np.percentile's result bit-for-bit at the end.
+
+    K is sized once, from the planned sample count and the first sample's row
+    count with a 4x row headroom; `result` re-derives the rank it needs from the
+    ACTUAL n and raises if K turned out too small (wildly varying sample sizes),
+    so a result can never be silently wrong. Percentiles low enough to make K
+    huge (the streaming advantage vanishes) are rejected up front.
+    """
+
+    MAX_K = 8192
+
+    def __init__(self, percentile, planned_samples=None):
+        self.percentile = float(percentile)
+        # planned_samples=None means "unbounded dataloader": size K for 1024
+        # samples and let `result` catch the (pathological) overflow.
+        self.planned_samples = planned_samples
+        self.k = None
+        self.state = {}  # name -> {"topk": (<=K, C) array, "n": int, "shape": tuple}
+
+    @staticmethod
+    def _to_rows(data):
+        """|data| reshaped to (rows, channels); same layouts as _get_max_per_channel."""
+        if len(data.shape) == 3:
+            return np.abs(np.reshape(data, (-1, data.shape[-1])))
+        if len(data.shape) == 4:
+            tensor = np.swapaxes(data, 1, -1)
+            return np.abs(np.reshape(tensor, (-1, tensor.shape[-1])))
+        if len(data.shape) == 2:
+            return np.abs(data)
+        assert False, "not supported"
+
+    def _needed_k(self, n):
+        return int(math.ceil((n - 1) * (1.0 - self.percentile / 100.0))) + 1
+
+    def _size_k(self, first_sample_rows):
+        planned = self.planned_samples if self.planned_samples else 1024
+        est_n = max(first_sample_rows, 1) * planned * 4
+        k = self._needed_k(est_n) + 8
+        if k > self.MAX_K:
+            raise ValueError(
+                "percentile {} over an estimated {} rows needs a top-{} per channel, "
+                "beyond the streaming reducer's cap of {}; use a higher percentile or "
+                "fewer/shorter calibration samples".format(self.percentile, est_n, k, self.MAX_K)
+            )
+        return k
+
+    def add(self, name, data):
+        data = np.asarray(data)
+        rows = self._to_rows(data)
+        if self.k is None:
+            self.k = self._size_k(rows.shape[0])
+        st = self.state.get(name)
+        if st is None:
+            st = self.state[name] = {
+                "topk": np.empty((0, rows.shape[-1]), dtype=rows.dtype),
+                "n": 0,
+                "shape": tuple(data.shape),
+            }
+        st["n"] += rows.shape[0]
+        if rows.shape[0] > self.k:
+            rows = np.partition(rows, rows.shape[0] - self.k, axis=0)[rows.shape[0] - self.k :]
+        merged = np.concatenate([st["topk"], rows], axis=0)
+        if merged.shape[0] > self.k:
+            merged = np.partition(merged, merged.shape[0] - self.k, axis=0)[merged.shape[0] - self.k :]
+        st["topk"] = merged
+
+    def shape(self, name):
+        """Shape of the first collected sample for this tensor."""
+        return self.state[name]["shape"]
+
+    def result(self, name):
+        """The per-channel percentile, exactly as np.percentile(stacked, q, axis=0)."""
+        st = self.state[name]
+        n = st["n"]
+        if n == 0:
+            raise RuntimeError("no samples were collected for tensor {}".format(name))
+        sbuf = np.sort(st["topk"], axis=0)  # ascending per channel, the global top-m
+        m = sbuf.shape[0]
+        virtual = self.percentile / 100.0 * (n - 1)
+        f = int(np.floor(virtual))
+        gamma = virtual - f
+        c = min(f + 1, n - 1)
+        f_buf = f - (n - m)
+        c_buf = c - (n - m)
+        if f_buf < 0:
+            raise RuntimeError(
+                "streaming top-{} per channel cannot reach rank {} of {} rows for tensor "
+                "{}; the calibration set grew far beyond the planned sample count".format(m, f, n, name)
+            )
+        # replicate numpy exactly so the streamed result is bit-identical to the
+        # stacked np.percentile: quantile promotes sub-double floats to float64
+        # before its _lerp (which rearranges the formula when t >= 0.5)
+        a = sbuf[f_buf].astype(np.float64)
+        b = sbuf[c_buf].astype(np.float64)
+        diff = b - a
+        if gamma >= 0.5:
+            res = b - diff * (1 - gamma)
+        else:
+            res = a + diff * gamma
+        return res.astype(np.single)
 
 
-def save_acts_sample(checkpoint_dir, keys, index, sample):
-    """Dump one collected sample's activations (atomically) as smooth-acts/sample-NNNNN.npz,
-    arrays positional in the order of `keys` (recorded once in names.json: npz keys cannot
-    safely hold every ONNX tensor-name character)."""
-    d = _acts_dir(checkpoint_dir)
-    d.mkdir(parents=True, exist_ok=True)
-    names_file = d / "names.json"
-    if not names_file.exists():
-        tmp = str(names_file) + ".tmp"
-        with open(tmp, "w") as f:
-            json.dump(list(keys), f)
-        os.replace(tmp, names_file)
-    path = d / "sample-{:05d}.npz".format(index)
+def save_stream_checkpoint(checkpoint_dir, keys, reducer, collected):
+    """Atomically dump the streaming reducer's state (per tensor: top-K buffer + row
+    count) plus the collected-sample count as one npz; small (K is tiny), so unlike
+    the raw activations this can be flushed cheaply mid-pass. Arrays are positional
+    in `keys` order (npz keys cannot safely hold every ONNX tensor-name character);
+    the json metadata rides inside the npz so the whole checkpoint is one atomic file."""
+    meta = {
+        "names": list(keys),
+        "percentile": reducer.percentile,
+        "k": reducer.k,
+        "collected": collected,
+        "shapes": [list(reducer.state[name]["shape"]) for name in keys],
+    }
+    arrays = {}
+    for i, name in enumerate(keys):
+        st = reducer.state[name]
+        arrays["topk_{}".format(i)] = st["topk"]
+        arrays["n_{}".format(i)] = np.array(st["n"])
+    path = pathlib.Path(checkpoint_dir) / STREAM_STATE_FILE
     tmp = str(path) + ".tmp"
     with open(tmp, "wb") as f:
-        np.savez(f, *[sample[k] for k in keys])
+        np.savez(f, meta=np.array(json.dumps(meta)), **arrays)
     os.replace(tmp, path)
+
+
+def load_stream_checkpoint(checkpoint_dir, keys, reducer):
+    """Restore an interrupted pass's reducer state; returns the number of samples it
+    already collected (0 if absent/stale). The dumped tensor set and percentile must
+    match exactly (same op_types/percentile config); on mismatch the stale state is
+    deleted and 0 returned, so a changed configuration can never half-resume into
+    wrong numerics."""
+    path = pathlib.Path(checkpoint_dir) / STREAM_STATE_FILE
+    if not path.exists():
+        return 0
+    try:
+        with np.load(path) as z:
+            meta = json.loads(z["meta"].item())
+            if meta["names"] != list(keys) or meta["percentile"] != reducer.percentile:
+                raise ValueError("dumped for a different tensor set or percentile")
+            state = {}
+            for i, name in enumerate(keys):
+                state[name] = {
+                    "topk": z["topk_{}".format(i)],
+                    "n": int(z["n_{}".format(i)]),
+                    "shape": tuple(meta["shapes"][i]),
+                }
+    except Exception as e:
+        logger.warning("discarding stale smooth-stream checkpoint in {} ({})".format(checkpoint_dir, e))
+        clear_stream_checkpoint(checkpoint_dir)
+        return 0
+    reducer.k = meta["k"]
+    reducer.state = state
+    return int(meta["collected"])
 
 
 class Calibrator:
@@ -111,13 +238,13 @@ class Calibrator:
             dataloader (data_reader.CalibrationDataReader): user implemented object to read in and preprocess calibration dataset.
             iterations (List[int], optional): tensor of which iteration will be collected. Defaults to [].
             providers (List[str], optional): execution provider for onnxruntime. Defaults to ["CPUExecutionProvider"].
-            checkpoint_dir (str, optional): when set, the collected per-sample activations
-                are periodically dumped under <checkpoint_dir>/smooth-acts/ and reloaded on
-                the next run, so an interrupted calibration pass resumes mid-pass instead of
-                redoing every forward.
+            checkpoint_dir (str, optional): when set, the streaming reducer's state (small:
+                per-channel top-K + counts) is periodically dumped to
+                <checkpoint_dir>/smooth-stream.npz and reloaded on the next run, so an
+                interrupted calibration pass resumes mid-pass instead of redoing every
+                forward.
             checkpoint_interval_sec (float, optional): minimum seconds between those dumps
-                (they are activation-sized, so a fast pass should not pay the IO; 0 dumps
-                after every sample). Defaults to 1200 (20 minutes).
+                (0 dumps after every sample). Defaults to 1200 (20 minutes).
         """
         self.model_wrapper = model
         self.dataloader = dataloader
@@ -212,7 +339,7 @@ class Calibrator:
         max_per_channels = max_per_channels.astype(np.single)
         return max_per_channels
 
-    def get_intermediate_outputs(self, checkpoint_keys=None):
+    def get_intermediate_outputs(self, checkpoint_keys=None, reducer=None):
         so = onnxruntime.SessionOptions()
         if sys.version_info < (3, 11) and importlib.util.find_spec("onnxruntime_extensions"):  # pragma: no cover
             from onnxruntime_extensions import get_library_path
@@ -256,48 +383,42 @@ class Calibrator:
             name_to_node[data_name] = node.name
 
         def _collect_data(ort_inputs):
-            for output_idx, output in enumerate(session.run(None, ort_inputs)):
-                output_dicts.setdefault(node_output_names[output_idx], []).append(output)
+            outputs = session.run(None, ort_inputs)
+            if reducer is not None:
+                # streaming: fold each smoothed tensor into the reducer and free the
+                # sample; nothing is retained, so memory stays flat over the pass
+                by_name = dict(zip(node_output_names, outputs))
+                for key in checkpoint_keys:
+                    reducer.add(key, by_name[key])
+            else:
+                for output_idx, output in enumerate(outputs):
+                    output_dicts.setdefault(node_output_names[output_idx], []).append(output)
 
-        # Mid-pass resume: samples already dumped by an interrupted run are restored from
-        # the checkpoint and their forwards skipped entirely. Only checkpoint_keys (the
-        # smoothed tensors, the only ones calib_smooth reads) are dumped/restored, not the
-        # model's real outputs. Dumps are time-gated (the state is activation-sized): on a
-        # fast pass nothing is ever written; on a slow pass at most checkpoint_interval_sec
-        # of forwards can be lost to a crash.
-        checkpoint_on = bool(self.checkpoint_dir and checkpoint_keys)
+        # Mid-pass resume (streaming mode only): an interrupted run's reducer state is
+        # restored and the forwards of the samples it already folded in are skipped
+        # entirely. The state is tiny (per-channel top-K + counts), so the time-gated
+        # dump costs little even on a slow pass; at most checkpoint_interval_sec of
+        # forwards can be lost to a crash.
+        checkpoint_on = bool(self.checkpoint_dir and checkpoint_keys and reducer is not None)
         restored = 0
         if checkpoint_on:
-            for sample in load_acts_checkpoint(self.checkpoint_dir, checkpoint_keys):
-                for name, arr in sample.items():
-                    output_dicts.setdefault(name, []).append(arr)
-                restored += 1
+            restored = load_stream_checkpoint(self.checkpoint_dir, checkpoint_keys, reducer)
             if restored:
                 logger.info(
-                    "smooth-acts checkpoint: restored {} collected sample(s); "
-                    "skipping their forwards".format(restored)
+                    "smooth-stream checkpoint: restored the state of {} collected "
+                    "sample(s); skipping their forwards".format(restored)
                 )
-        state = {"collected": 0, "pending": [], "last_flush": time.time(), "flushed": False}
-
-        def _flush_pending():
-            for index, sample in state["pending"]:
-                save_acts_sample(self.checkpoint_dir, checkpoint_keys, index, sample)
-            state["pending"].clear()
-            state["last_flush"] = time.time()
-            state["flushed"] = True
+        state = {"collected": 0, "last_flush": time.time()}
 
         def _consume(ort_inputs):
             if state["collected"] < restored:
-                state["collected"] += 1  # already restored from the checkpoint
+                state["collected"] += 1  # already folded into the restored state
                 return
             _collect_data(ort_inputs)
-            if checkpoint_on:
-                state["pending"].append(
-                    (state["collected"], {k: output_dicts[k][-1] for k in checkpoint_keys})
-                )
-                if time.time() - state["last_flush"] >= self.checkpoint_interval_sec:
-                    _flush_pending()
             state["collected"] += 1
+            if checkpoint_on and time.time() - state["last_flush"] >= self.checkpoint_interval_sec:
+                save_stream_checkpoint(self.checkpoint_dir, checkpoint_keys, reducer, state["collected"])
+                state["last_flush"] = time.time()
 
         # This per-sample forward pass over the calibration set is the slow, otherwise
         # silent phase logged as "Start smooth model calibration"; show its progress.
@@ -319,13 +440,8 @@ class Calibrator:
             idx += 1
             pbar.update(1)
         pbar.close()
-        # Flush the tail only when a periodic flush already happened: a pass slow enough
-        # to have flushed deserves a complete checkpoint (the np.percentile reduction and
-        # the smooth-calib save still lie ahead and can OOM), while a fast pass should
-        # not suddenly write gigabytes that the full smooth-calib checkpoint supersedes
-        # moments later.
-        if checkpoint_on and state["flushed"] and state["pending"]:
-            _flush_pending()
+        # No tail flush: the full smooth-calib checkpoint is written immediately after
+        # this pass returns and supersedes the mid-pass state anyway.
         return output_dicts
 
     def calib_smooth(self, op_types, percentile: float = 99.999):
@@ -346,7 +462,13 @@ class Calibrator:
         # add the input tensors of {op_types} to outputs of the model
         tensors_to_node = self._get_input_tensor_of_ops(op_types)
         self.model_wrapper.add_tensors_to_outputs(tensors_to_node.keys())
-        output_dicts = self.get_intermediate_outputs(checkpoint_keys=list(tensors_to_node.keys()))
+        # Stream the percentile instead of stacking every sample: each collected
+        # sample is folded into a per-channel top-K and freed, so the pass holds
+        # O(K x channels) instead of O(samples x frames x channels) (which reached
+        # hundreds of GB on long-window runs). The result is bit-identical to the
+        # stacked np.percentile (see StreamingChannelPercentile).
+        reducer = StreamingChannelPercentile(percentile, planned_samples=len(self.iterations) or None)
+        self.get_intermediate_outputs(checkpoint_keys=list(tensors_to_node.keys()), reducer=reducer)
 
         # remove the input tensors of {op_types} to outputs of the model
         self.model_wrapper.remove_tensors_from_outputs(tensors_to_node.keys())
@@ -354,9 +476,8 @@ class Calibrator:
         shape_infos = {}
 
         for key, val in tensors_to_node.items():
-            max_val_per_channel = self._get_max_per_channel(output_dicts[key], percentile=percentile)
-            max_vals_per_channel[key] = max_val_per_channel
-            shape_infos[key] = output_dicts[key][0].shape
+            max_vals_per_channel[key] = reducer.result(key)
+            shape_infos[key] = reducer.shape(key)
             for item in val:
                 shape_infos[item[1][1]] = self.model_wrapper.get_initializer(item[1][1]).dims
         return max_vals_per_channel, shape_infos, tensors_to_node

--- a/onnx_neural_compressor/algorithms/smoother/calibrator.py
+++ b/onnx_neural_compressor/algorithms/smoother/calibrator.py
@@ -14,9 +14,13 @@
 """Calibration for smooth quant."""
 
 import importlib.util
+import json
+import os
 import pathlib
+import shutil
 import sys
 import tempfile
+import time
 from typing import List
 
 import numpy as np
@@ -28,6 +32,65 @@ from onnx_neural_compressor import data_reader, logger, onnx_model, utility
 from onnx_neural_compressor.algorithms import utility as quant_utils
 
 
+def _acts_dir(checkpoint_dir):
+    return pathlib.Path(checkpoint_dir) / "smooth-acts"
+
+
+def clear_acts_checkpoint(checkpoint_dir):
+    """Remove the partial per-sample activation dumps. Called once the FULL smooth-calib
+    checkpoint exists (the per-sample files are superseded, and they are the bulky part:
+    every smoothed tensor's activation for every collected sample)."""
+    shutil.rmtree(_acts_dir(checkpoint_dir), ignore_errors=True)
+
+
+def load_acts_checkpoint(checkpoint_dir, keys):
+    """Restore the per-sample activation dumps of an interrupted calibration pass.
+
+    Returns a list of {tensor_name: array} dicts for the contiguous samples 0..k-1
+    found in <checkpoint_dir>/smooth-acts/. The dumped tensor set must match `keys`
+    exactly (same op_types config); on mismatch the stale dump is deleted and []
+    returned, so a changed configuration can never half-resume into wrong numerics."""
+    d = _acts_dir(checkpoint_dir)
+    names_file = d / "names.json"
+    if not names_file.exists():
+        return []
+    with open(names_file) as f:
+        names = json.load(f)
+    if names != list(keys):
+        logger.warning(
+            "smooth-acts checkpoint in {} was dumped for a different tensor set; discarding it".format(d)
+        )
+        clear_acts_checkpoint(checkpoint_dir)
+        return []
+    samples = []
+    while True:
+        f = d / "sample-{:05d}.npz".format(len(samples))
+        if not f.exists():
+            break
+        with np.load(f) as z:
+            samples.append({n: z["arr_{}".format(j)] for j, n in enumerate(names)})
+    return samples
+
+
+def save_acts_sample(checkpoint_dir, keys, index, sample):
+    """Dump one collected sample's activations (atomically) as smooth-acts/sample-NNNNN.npz,
+    arrays positional in the order of `keys` (recorded once in names.json: npz keys cannot
+    safely hold every ONNX tensor-name character)."""
+    d = _acts_dir(checkpoint_dir)
+    d.mkdir(parents=True, exist_ok=True)
+    names_file = d / "names.json"
+    if not names_file.exists():
+        tmp = str(names_file) + ".tmp"
+        with open(tmp, "w") as f:
+            json.dump(list(keys), f)
+        os.replace(tmp, names_file)
+    path = d / "sample-{:05d}.npz".format(index)
+    tmp = str(path) + ".tmp"
+    with open(tmp, "wb") as f:
+        np.savez(f, *[sample[k] for k in keys])
+    os.replace(tmp, path)
+
+
 class Calibrator:
     """Dump information for smooth quant."""
 
@@ -37,6 +100,8 @@ class Calibrator:
         dataloader: data_reader.CalibrationDataReader,
         iterations: List[int] = [],
         providers: List[str] = ["CPUExecutionProvider"],
+        checkpoint_dir=None,
+        checkpoint_interval_sec: float = 1200,
         **kwargs,
     ):
         """Initialize a Calibrator to dump information.
@@ -46,12 +111,21 @@ class Calibrator:
             dataloader (data_reader.CalibrationDataReader): user implemented object to read in and preprocess calibration dataset.
             iterations (List[int], optional): tensor of which iteration will be collected. Defaults to [].
             providers (List[str], optional): execution provider for onnxruntime. Defaults to ["CPUExecutionProvider"].
+            checkpoint_dir (str, optional): when set, the collected per-sample activations
+                are periodically dumped under <checkpoint_dir>/smooth-acts/ and reloaded on
+                the next run, so an interrupted calibration pass resumes mid-pass instead of
+                redoing every forward.
+            checkpoint_interval_sec (float, optional): minimum seconds between those dumps
+                (they are activation-sized, so a fast pass should not pay the IO; 0 dumps
+                after every sample). Defaults to 1200 (20 minutes).
         """
         self.model_wrapper = model
         self.dataloader = dataloader
         self.augmented_model = None
         self.iterations = iterations
         self.providers = providers
+        self.checkpoint_dir = checkpoint_dir
+        self.checkpoint_interval_sec = checkpoint_interval_sec
 
     def _check_is_group_conv(self, node):
         """Check the op is group wised or not(depthwise conv is excluded,return false).
@@ -138,7 +212,7 @@ class Calibrator:
         max_per_channels = max_per_channels.astype(np.single)
         return max_per_channels
 
-    def get_intermediate_outputs(self):
+    def get_intermediate_outputs(self, checkpoint_keys=None):
         so = onnxruntime.SessionOptions()
         if sys.version_info < (3, 11) and importlib.util.find_spec("onnxruntime_extensions"):  # pragma: no cover
             from onnxruntime_extensions import get_library_path
@@ -185,6 +259,46 @@ class Calibrator:
             for output_idx, output in enumerate(session.run(None, ort_inputs)):
                 output_dicts.setdefault(node_output_names[output_idx], []).append(output)
 
+        # Mid-pass resume: samples already dumped by an interrupted run are restored from
+        # the checkpoint and their forwards skipped entirely. Only checkpoint_keys (the
+        # smoothed tensors, the only ones calib_smooth reads) are dumped/restored, not the
+        # model's real outputs. Dumps are time-gated (the state is activation-sized): on a
+        # fast pass nothing is ever written; on a slow pass at most checkpoint_interval_sec
+        # of forwards can be lost to a crash.
+        checkpoint_on = bool(self.checkpoint_dir and checkpoint_keys)
+        restored = 0
+        if checkpoint_on:
+            for sample in load_acts_checkpoint(self.checkpoint_dir, checkpoint_keys):
+                for name, arr in sample.items():
+                    output_dicts.setdefault(name, []).append(arr)
+                restored += 1
+            if restored:
+                logger.info(
+                    "smooth-acts checkpoint: restored {} collected sample(s); "
+                    "skipping their forwards".format(restored)
+                )
+        state = {"collected": 0, "pending": [], "last_flush": time.time(), "flushed": False}
+
+        def _flush_pending():
+            for index, sample in state["pending"]:
+                save_acts_sample(self.checkpoint_dir, checkpoint_keys, index, sample)
+            state["pending"].clear()
+            state["last_flush"] = time.time()
+            state["flushed"] = True
+
+        def _consume(ort_inputs):
+            if state["collected"] < restored:
+                state["collected"] += 1  # already restored from the checkpoint
+                return
+            _collect_data(ort_inputs)
+            if checkpoint_on:
+                state["pending"].append(
+                    (state["collected"], {k: output_dicts[k][-1] for k in checkpoint_keys})
+                )
+                if time.time() - state["last_flush"] >= self.checkpoint_interval_sec:
+                    _flush_pending()
+            state["collected"] += 1
+
         # This per-sample forward pass over the calibration set is the slow, otherwise
         # silent phase logged as "Start smooth model calibration"; show its progress.
         total = (max(self.iterations) + 1) if self.iterations else None
@@ -199,12 +313,19 @@ class Calibrator:
                 if idx > max(self.iterations):
                     break
                 if idx in self.iterations:
-                    _collect_data(inputs)
+                    _consume(inputs)
             else:
-                _collect_data(inputs)
+                _consume(inputs)
             idx += 1
             pbar.update(1)
         pbar.close()
+        # Flush the tail only when a periodic flush already happened: a pass slow enough
+        # to have flushed deserves a complete checkpoint (the np.percentile reduction and
+        # the smooth-calib save still lie ahead and can OOM), while a fast pass should
+        # not suddenly write gigabytes that the full smooth-calib checkpoint supersedes
+        # moments later.
+        if checkpoint_on and state["flushed"] and state["pending"]:
+            _flush_pending()
         return output_dicts
 
     def calib_smooth(self, op_types, percentile: float = 99.999):
@@ -225,7 +346,7 @@ class Calibrator:
         # add the input tensors of {op_types} to outputs of the model
         tensors_to_node = self._get_input_tensor_of_ops(op_types)
         self.model_wrapper.add_tensors_to_outputs(tensors_to_node.keys())
-        output_dicts = self.get_intermediate_outputs()
+        output_dicts = self.get_intermediate_outputs(checkpoint_keys=list(tensors_to_node.keys()))
 
         # remove the input tensors of {op_types} to outputs of the model
         self.model_wrapper.remove_tensors_from_outputs(tensors_to_node.keys())

--- a/onnx_neural_compressor/algorithms/smoother/core.py
+++ b/onnx_neural_compressor/algorithms/smoother/core.py
@@ -43,22 +43,25 @@ def _quiet_session_options():
     return so
 
 
-def _get_quant_dequant_output(model, input_data, output_data, providers):
-    """Get loss between fp32 output and QDQ output.
+def _build_qdq_session(model, providers):
+    """Build the single-node QDQ sub-graph session used to score one (node, alpha).
 
-    Args:
-        model (object): model
-        input_data (numpy.ndarray): fp32 input
-        output_data (numpy.ndarray): fp32 output
-        providers (list): execution provider
+    For a fixed (node, alpha) this sub-graph is identical across every calibration sample,
+    so the session is built ONCE here and reused by _qdq_loss for all samples, instead of
+    rebuilt per sample (the old _get_quant_dequant_output did the latter, which on the large
+    path was the dominant remaining cost once activations were cached).
     """
-    input_data = quant_utils.qdq_data(input_data, 2, False)
-    sess = ort.InferenceSession(
+    return ort.InferenceSession(
         model.SerializeToString(), sess_options=_quiet_session_options(), providers=providers
     )
-    preds = sess.run(None, {model.graph.input[0].name: input_data})
-    loss = np.sum(np.abs(output_data - preds) ** 2)
-    return loss
+
+
+def _qdq_loss(session, input_name, input_data, output_data):
+    """Sum-of-squares loss between the fp32 reference output and the QDQ sub-graph output
+    for one calibration sample, against a prebuilt session (see _build_qdq_session)."""
+    input_data = quant_utils.qdq_data(input_data, 2, False)
+    preds = session.run(None, {input_name: input_data})
+    return np.sum(np.abs(output_data - preds) ** 2)
 
 
 def _make_sub_graph(node, inits, input_data, output_data, opset, ir_version):
@@ -418,18 +421,21 @@ class Smoother:
             inits = [self.model.get_initializer(i) for i in node.input if self.model.get_initializer(i) is not None]
 
             self.dataloader.rewind()
-            model = None
+            sub_sess = None
+            sub_input = None
             while True:
                 inputs = self.dataloader.get_next()
                 if not inputs:
                     break
                 outputs = session.run(added_tensors, inputs)
-                if model is None:
+                if sub_sess is None:
                     model = _make_sub_graph(
                         node, inits, outputs[0], outputs[1],
                         self.model.model.opset_import, self.model.model.ir_version,
                     )
-                loss += _get_quant_dequant_output(model, outputs[0] * scale, outputs[1], self.providers)
+                    sub_sess = _build_qdq_session(model, self.providers)
+                    sub_input = model.graph.input[0].name
+                loss += _qdq_loss(sub_sess, sub_input, outputs[0] * scale, outputs[1])
             self.model.remove_tensors_from_outputs([i for i in added_tensors if i not in orig_outputs])
             self.model.set_initializer(node.input[1], weight)
             return loss
@@ -463,14 +469,17 @@ class Smoother:
                 collected.append((out0, out1))
             self._sq_out_cache = {"node": node_name, "outputs": collected}
 
-        model = None
+        sub_sess = None
+        sub_input = None
         for out0, out1 in self._sq_out_cache["outputs"]:
-            if model is None:
+            if sub_sess is None:
                 model = _make_sub_graph(
                     node, inits, out0, out1,
                     self.model.model.opset_import, self.model.model.ir_version,
                 )
-            loss += _get_quant_dequant_output(model, out0 * scale, out1, self.providers)
+                sub_sess = _build_qdq_session(model, self.providers)
+                sub_input = model.graph.input[0].name
+            loss += _qdq_loss(sub_sess, sub_input, out0 * scale, out1)
         self.model.set_initializer(node.input[1], weight)
         return loss
 

--- a/onnx_neural_compressor/algorithms/smoother/core.py
+++ b/onnx_neural_compressor/algorithms/smoother/core.py
@@ -44,23 +44,27 @@ def _quiet_session_options():
 
 
 def _build_qdq_session(model, providers):
-    """Build the single-node QDQ sub-graph session used to score one (node, alpha).
+    """Build the single-node QDQ sub-graph session used to score a node across the alpha grid.
 
-    For a fixed (node, alpha) this sub-graph is identical across every calibration sample,
-    so the session is built ONCE here and reused by _qdq_loss for all samples, instead of
-    rebuilt per sample (the old _get_quant_dequant_output did the latter, which on the large
-    path was the dominant remaining cost once activations were cached).
+    The sub-graph feeds BOTH the activation and the (alpha-dependent) quant-dequant weight
+    as runtime inputs (see _make_sub_graph), so for a fixed node it is identical across every
+    calibration sample AND every alpha. The session is therefore built ONCE per node and
+    reused by _qdq_loss for all samples and all alphas, instead of rebuilt per (node, alpha)
+    -- which was n_alphas sessions per node and made a wide alpha grid balloon native memory
+    (each ort.InferenceSession arena is never handed back to the OS) until it OOM'd.
     """
     return ort.InferenceSession(
         model.SerializeToString(), sess_options=_quiet_session_options(), providers=providers
     )
 
 
-def _qdq_loss(session, input_name, input_data, output_data):
+def _qdq_loss(session, input_name, input_data, output_data, weight_name, weight_data):
     """Sum-of-squares loss between the fp32 reference output and the QDQ sub-graph output
-    for one calibration sample, against a prebuilt session (see _build_qdq_session)."""
+    for one calibration sample, against a prebuilt session (see _build_qdq_session). Both the
+    quant-dequant activation and the (alpha-dependent) quant-dequant weight are fed per call,
+    so one session serves the whole alpha grid."""
     input_data = quant_utils.qdq_data(input_data, 2, False)
-    preds = session.run(None, {input_name: input_data})
+    preds = session.run(None, {input_name: input_data, weight_name: weight_data})
     return np.sum(np.abs(output_data - preds) ** 2)
 
 
@@ -89,14 +93,23 @@ def _format_alpha_summary(rows):
     return lines
 
 
-def _make_sub_graph(node, inits, input_data, output_data, opset, ir_version):
-    """Build a model with the specific node.
+def _make_sub_graph(node, inits, input_data, output_data, weight_name, weight_data, opset, ir_version):
+    """Build a single-node model whose weight is a runtime INPUT, not a baked initializer.
+
+    The QDQ-loss sub-graph is structurally identical for every alpha at a given node (same
+    node, same activation/weight shapes); only the quant-dequant weight VALUES change with
+    alpha. Feeding the weight as a graph input (instead of baking the alpha-dependent weight
+    as an initializer) makes the built session reusable across the whole alpha grid, so it is
+    built once per node rather than once per (node, alpha). bias / other non-weight
+    initializers are alpha-independent and stay baked in ``inits``.
 
     Args:
         node (object): node
-        inits (list): initializer inputs of this node
-        input_data (numpy.ndarray): fp32 input
-        output_data (numpy.ndarray): fp32 output
+        inits (list): non-weight initializer inputs of this node (e.g. bias), kept baked
+        input_data (numpy.ndarray): fp32 activation input (used for its dtype/shape)
+        output_data (numpy.ndarray): fp32 output (used for its dtype/shape)
+        weight_name (str): name of the weight input fed at run time (node.input[1])
+        weight_data (numpy.ndarray): quant-dequant weight (used for its dtype/shape)
         opset (object): opset of the model
         ir_version (object): ir_version of the model
     """
@@ -105,12 +118,17 @@ def _make_sub_graph(node, inits, input_data, output_data, opset, ir_version):
         onnx.helper.np_dtype_to_tensor_dtype(input_data.dtype),
         input_data.shape,
     )
+    weight = onnx.helper.make_tensor_value_info(
+        weight_name,
+        onnx.helper.np_dtype_to_tensor_dtype(weight_data.dtype),
+        weight_data.shape,
+    )
     output = onnx.helper.make_tensor_value_info(
         node.output[0],
         onnx.helper.np_dtype_to_tensor_dtype(output_data.dtype),
         output_data.shape,
     )
-    graph = onnx.helper.make_graph([node], "sub_graph", [input], [output], inits)
+    graph = onnx.helper.make_graph([node], "sub_graph", [input, weight], [output], inits)
     model = onnx.helper.make_model(graph, opset_imports=opset)
     model.ir_version = ir_version
     return model
@@ -162,6 +180,10 @@ class Smoother:
         # alpha grid (the activations are alpha-independent on the large path).
         self._sq_shared_session = None
         self._sq_out_cache = {"node": None, "outputs": None}
+        # Per-node QDQ sub-graph session, reused across the whole alpha grid (the weight is
+        # fed as a runtime input, so the session is alpha-independent). Built once per node
+        # instead of once per (node, alpha) -- see _make_sub_graph / _get_output_loss.
+        self._sq_subgraph = {"node": None, "session": None, "input": None, "weight": None}
         # Quiets _adjust_weights' own tqdm bar while it is called once per (node, alpha)
         # inside the auto-alpha search (where the single auto-alpha bar is the real signal);
         # the final single full-model apply in transform() re-enables it.
@@ -409,29 +431,21 @@ class Smoother:
                                         child.input[idx] = node.input[0]
         self.model.remove_nodes(remove_nodes)
 
-    def _get_output_loss(self, node_name, scale, calib_iter):
-        """Get output loss of specific node after inserting QDQ pair.
+    def _reference_activations(self, node, node_name):
+        """Return the per-sample (node-input, node-output) reference activations the QDQ loss
+        scores against, as a list of (np.ndarray, np.ndarray).
 
-        Args:
-            node_name (str): node name
-            scale (float): scale of the specific node
-            calib_iter (int): iterations
+        Small model: recomputed every call from a fresh full-model session (the activations
+        depend on the just-smoothed weights, so they are not cacheable across the alpha grid).
+        Large model: harvested ONCE per node from the shared ORIGINAL-weight augment session
+        (alpha-independent) and cached across the whole grid.
 
-        The calibration ``dataloader`` is rewound before every evaluation: the alpha
-        search drains it once in ``_dump_op_info`` and never rewinds before searching,
-        so without this each evaluation would see an exhausted reader (loss 0) and the
-        per-layer optimal alpha would collapse to ``alpha_min`` for every node.
+        The calibration ``dataloader`` is rewound before every harvest: the alpha search
+        drains it once in ``_dump_op_info`` and never rewinds before searching, so without
+        this each evaluation would see an exhausted reader (loss 0) and the per-layer optimal
+        alpha would collapse to ``alpha_min`` for every node.
         """
-        node = [i for i in self.model.nodes() if i.name == node_name]
-        loss = 0
-        if len(node) == 0:
-            return loss
-        node = node[0]
-
         if not self.model.is_large_model:
-            # Small model: the session is cheap to rebuild and must be rebuilt every
-            # call (the weight was just scaled for this alpha), so keep doing that and
-            # only add the missing rewind.
             orig_outputs = self.model.output()
             added_tensors = [node.input[0], node.output[0]]
             self.model.add_tensors_to_outputs(added_tensors)
@@ -440,42 +454,21 @@ class Smoother:
                 sess_options=_quiet_session_options(),
                 providers=self.providers,
             )
-            weight = onnx.numpy_helper.to_array(self.model.get_initializer(node.input[1]), "")
-            weight_q = quant_utils.qdq_data(weight, 3, True)
-            self.model.set_initializer(node.input[1], weight_q)
-            inits = [self.model.get_initializer(i) for i in node.input if self.model.get_initializer(i) is not None]
-
+            self.model.remove_tensors_from_outputs([i for i in added_tensors if i not in orig_outputs])
             self.dataloader.rewind()
-            sub_sess = None
-            sub_input = None
+            samples = []
             while True:
                 inputs = self.dataloader.get_next()
                 if not inputs:
                     break
-                outputs = session.run(added_tensors, inputs)
-                if sub_sess is None:
-                    model = _make_sub_graph(
-                        node, inits, outputs[0], outputs[1],
-                        self.model.model.opset_import, self.model.model.ir_version,
-                    )
-                    sub_sess = _build_qdq_session(model, self.providers)
-                    sub_input = model.graph.input[0].name
-                loss += _qdq_loss(sub_sess, sub_input, outputs[0] * scale, outputs[1])
-            self.model.remove_tensors_from_outputs([i for i in added_tensors if i not in orig_outputs])
-            self.model.set_initializer(node.input[1], weight)
-            return loss
+                out0, out1 = session.run(added_tensors, inputs)
+                samples.append((out0, out1))
+            return samples
 
-        # Large model: the augment file (saved once in _auto_tune_alpha with the
-        # ORIGINAL weights and every per-node in/out tensor exposed as a graph output)
-        # backs ONE shared session whose harvested activations are alpha-independent.
-        # Harvest each node's activations once and cache them across the whole alpha
-        # grid; only the cheap per-alpha QDQ sub-graph depends on the scaled weight.
-        base_dir = os.path.dirname(self.model.model_path)
-        weight = onnx.numpy_helper.to_array(self.model.get_initializer(node.input[1]), base_dir)
-        weight_q = quant_utils.qdq_data(weight, 3, True)
-        self.model.set_initializer(node.input[1], weight_q)
-        inits = [self.model.get_initializer(i) for i in node.input if self.model.get_initializer(i) is not None]
-
+        # Large model: the augment file (saved once in _auto_tune_alpha with the ORIGINAL
+        # weights and every per-node in/out tensor exposed as a graph output) backs ONE
+        # shared session whose harvested activations are alpha-independent, so cache them
+        # per node across the whole alpha grid.
         if self._sq_out_cache.get("node") != node_name:
             if self._sq_shared_session is None:
                 self._sq_shared_session = ort.InferenceSession(
@@ -493,19 +486,63 @@ class Smoother:
                 out0, out1 = self._sq_shared_session.run(fetch, inputs)
                 collected.append((out0, out1))
             self._sq_out_cache = {"node": node_name, "outputs": collected}
+        return self._sq_out_cache["outputs"]
 
-        sub_sess = None
-        sub_input = None
-        for out0, out1 in self._sq_out_cache["outputs"]:
-            if sub_sess is None:
-                model = _make_sub_graph(
-                    node, inits, out0, out1,
-                    self.model.model.opset_import, self.model.model.ir_version,
-                )
-                sub_sess = _build_qdq_session(model, self.providers)
-                sub_input = model.graph.input[0].name
-            loss += _qdq_loss(sub_sess, sub_input, out0 * scale, out1)
-        self.model.set_initializer(node.input[1], weight)
+    def _get_output_loss(self, node_name, scale, calib_iter):
+        """Get output loss of specific node after inserting QDQ pair.
+
+        Args:
+            node_name (str): node name
+            scale (float): scale of the specific node
+            calib_iter (int): iterations
+
+        The (alpha-dependent) quant-dequant weight is the ONLY thing that changes across the
+        alpha grid for a fixed node, so it is fed to the sub-graph session as a runtime input
+        (see _make_sub_graph) and the session itself is built once per node and cached on
+        ``self._sq_subgraph``. This keeps the count of ort.InferenceSession builds at one per
+        node instead of one per (node, alpha): a wide alpha grid no longer multiplies session
+        churn (whose never-reclaimed native arenas were OOM-ing wide-grid searches).
+        """
+        node = [i for i in self.model.nodes() if i.name == node_name]
+        loss = 0
+        if len(node) == 0:
+            return loss
+        node = node[0]
+        base_dir = os.path.dirname(self.model.model_path) if self.model.model_path is not None else ""
+
+        # The quant-dequant weight is alpha-dependent (the weight was just scaled for this
+        # alpha by _adjust_weights); it is fed to the cached session per call. bias / other
+        # non-weight initializers are alpha-independent and stay baked into the sub-graph.
+        weight = onnx.numpy_helper.to_array(self.model.get_initializer(node.input[1]), base_dir)
+        weight_q = quant_utils.qdq_data(weight, 3, True)
+        extra_inits = [
+            self.model.get_initializer(i)
+            for i in node.input[2:]
+            if self.model.get_initializer(i) is not None
+        ]
+
+        samples = self._reference_activations(node, node_name)
+        if not samples:
+            return loss
+
+        if self._sq_subgraph.get("node") != node_name:
+            ref_in, ref_out = samples[0]
+            sub_model = _make_sub_graph(
+                node, extra_inits, ref_in, ref_out, node.input[1], weight_q,
+                self.model.model.opset_import, self.model.model.ir_version,
+            )
+            self._sq_subgraph = {
+                "node": node_name,
+                "session": _build_qdq_session(sub_model, self.providers),
+                "input": sub_model.graph.input[0].name,
+                "weight": node.input[1],
+            }
+        sub_sess = self._sq_subgraph["session"]
+        sub_input = self._sq_subgraph["input"]
+        weight_name = self._sq_subgraph["weight"]
+
+        for ref_in, ref_out in samples:
+            loss += _qdq_loss(sub_sess, sub_input, ref_in * scale, ref_out, weight_name, weight_q)
         return loss
 
     def _reshape_scale_for_input(self, tensor, key):
@@ -620,6 +657,7 @@ class Smoother:
         # makes the per-node cache in _get_output_loss valid.
         self._sq_shared_session = None
         self._sq_out_cache = {"node": None, "outputs": None}
+        self._sq_subgraph = {"node": None, "session": None, "input": None, "weight": None}
         added_outputs = []
         if self.model.is_large_model:
             needed, seen = [], set()
@@ -683,6 +721,7 @@ class Smoother:
                 self.model.remove_tensors_from_outputs(added_outputs)
             self._sq_shared_session = None
             self._sq_out_cache = {"node": None, "outputs": None}
+            self._sq_subgraph = {"node": None, "session": None, "input": None, "weight": None}
 
         logger.info("auto tuning alpha done")
         self._log_alpha_summary(optimal_alphas)

--- a/onnx_neural_compressor/algorithms/smoother/core.py
+++ b/onnx_neural_compressor/algorithms/smoother/core.py
@@ -14,6 +14,8 @@
 """Smoother for onnxrt."""
 
 import copy
+import io
+import json
 import os
 import pathlib
 
@@ -138,6 +140,81 @@ def select_worst_nodes(losses, spec):
     return ranked[:count]
 
 
+def _atomic_write_bytes(path, data):
+    """Write checkpoint bytes via a temp file + os.replace so a crash (OOM kill) mid-write
+    can never leave a truncated checkpoint behind: the file either has the previous
+    complete content or the new complete content."""
+    tmp = str(path) + ".tmp"
+    with open(tmp, "wb") as f:
+        f.write(data)
+    os.replace(tmp, str(path))
+
+
+def _smooth_calib_checkpoint_paths(checkpoint_dir):
+    d = pathlib.Path(checkpoint_dir)
+    return d / "smooth-calib.npz", d / "smooth-calib.json"
+
+
+def load_smooth_calib_checkpoint(checkpoint_dir):
+    """Load _dump_op_info's smoother-calibration results from a checkpoint dir, or None.
+
+    Returns (max_vals_per_channel, shape_info, tensors_to_node) when both checkpoint
+    files exist, else None. The npz holds the per-tensor activation-max arrays in the
+    order of the json's "max_vals_names" list (names live in the json because npz keys
+    cannot hold every ONNX tensor-name character safely)."""
+    npz_path, json_path = _smooth_calib_checkpoint_paths(checkpoint_dir)
+    if not (npz_path.exists() and json_path.exists()):
+        return None
+    with open(json_path) as f:
+        meta = json.load(f)
+    with np.load(npz_path) as npz:
+        max_vals = {name: npz[f"arr_{i}"] for i, name in enumerate(meta["max_vals_names"])}
+    return max_vals, meta["shape_info"], meta["tensors_to_node"]
+
+
+def save_smooth_calib_checkpoint(checkpoint_dir, max_vals_per_channel, shape_info, tensors_to_node):
+    """Persist _dump_op_info's results so a resumed run skips the smoother-calibration
+    forward passes entirely. shape_info values and tensors_to_node node.input/output
+    are protobuf repeated containers; both are converted to plain lists for json."""
+    npz_path, json_path = _smooth_calib_checkpoint_paths(checkpoint_dir)
+    names = list(max_vals_per_channel)
+    buf = io.BytesIO()
+    np.savez(buf, *[max_vals_per_channel[n] for n in names])
+    _atomic_write_bytes(npz_path, buf.getvalue())
+    meta = {
+        "max_vals_names": names,
+        "shape_info": {k: [int(d) for d in v] for k, v in shape_info.items()},
+        "tensors_to_node": {
+            k: [[ni[0], list(ni[1]), list(ni[2])] for ni in v] for k, v in tensors_to_node.items()
+        },
+    }
+    _atomic_write_bytes(json_path, json.dumps(meta).encode())
+
+
+def _alpha_checkpoint_path(checkpoint_dir):
+    return pathlib.Path(checkpoint_dir) / "alphas.json"
+
+
+def load_alpha_checkpoint(checkpoint_dir):
+    """Per-node auto-alpha results from a previous (possibly crashed) run, as
+    {node_name: {"key", "op_type", "alpha", "loss", "losses"}}. Empty when absent."""
+    path = _alpha_checkpoint_path(checkpoint_dir)
+    if not path.exists():
+        return {}
+    with open(path) as f:
+        return json.load(f).get("nodes", {})
+
+
+def save_alpha_checkpoint(checkpoint_dir, nodes):
+    """Rewrite the per-node alpha checkpoint (called after EVERY node's grid finishes,
+    so an OOM-killed search resumes from the last completed node). Also the run's
+    human-readable record of which alpha each layer picked and at what QDQ loss."""
+    _atomic_write_bytes(
+        _alpha_checkpoint_path(checkpoint_dir),
+        json.dumps({"nodes": nodes}, indent=1, sort_keys=True).encode(),
+    )
+
+
 def _make_sub_graph(node, inits, input_data, output_data, weight_name, weight_data, opset, ir_version):
     """Build a single-node model whose weight is a runtime INPUT, not a baked initializer.
 
@@ -249,6 +326,7 @@ class Smoother:
         scales_per_op: bool = True,
         calib_iter: int = 100,
         auto_alpha_args: dict = {"alpha_min": 0.3, "alpha_max": 0.7, "alpha_step": 0.05, "attn_method": "min"},
+        checkpoint_dir: Union[str, pathlib.Path, None] = None,
         *args,
         **kwargs
     ):
@@ -269,6 +347,14 @@ class Smoother:
             calib_iter (int, optional): iteration num for calibration. Defaults to 100.
             auto_alpha_args (_type_, optional): alpha args for auto smooth.
                 Defaults to {"alpha_min": 0.3, "alpha_max": 0.7, "alpha_step": 0.05, "attn_method": "min"}.
+            checkpoint_dir (str | pathlib.Path, optional): directory for resumable
+                intermediates. When set, the smoother-calibration results and the per-node
+                auto-alpha results are written there as they are produced (smooth-calib.npz/
+                .json, alphas.json) and any results already present are LOADED instead of
+                recomputed, so a crashed/OOM-killed run resumes from the last completed node
+                instead of restarting the whole search. Caller owns cache invalidation: the
+                files carry no model/config fingerprint, so a stale dir must not be reused
+                across different models, calibration data, or alpha grids.
 
         Returns:
             onnx.ModelProto: A FP32 model with the same architecture as the orig model
@@ -285,10 +371,10 @@ class Smoother:
                 alpha = 1.0
                 logger.warning("reset alpha to 1.0 ")
 
-        self._dump_op_info(percentile, op_types, calib_iter)
+        self._dump_op_info(percentile, op_types, calib_iter, checkpoint_dir=checkpoint_dir)
 
         if alpha == "auto":
-            alpha = self._auto_tune_alpha(calib_iter, **auto_alpha_args)
+            alpha = self._auto_tune_alpha(calib_iter, checkpoint_dir=checkpoint_dir, **auto_alpha_args)
 
         scales = self._get_smooth_scales(alpha)
         self._insert_smooth_mul_op(scales)
@@ -307,24 +393,40 @@ class Smoother:
         self.model.remove_unused_nodes()
         return self.model.model
 
-    def _dump_op_info(self, percentile, op_types, iterations):
+    def _dump_op_info(self, percentile, op_types, iterations, checkpoint_dir=None):
         """Dump op info for smooth quant.
 
         Args:
             percentile (float): percentile of calibration to remove outliers
             op_types (list): the op type to be smooth quantized
             iterations (int): iterations
+            checkpoint_dir (str, optional): when set, load the calibration results from
+                there if present (skipping every forward pass), else compute and save them
         """
-        sq_calibrator = calibrator.Calibrator(
-            self.model,
-            self.dataloader,
-            iterations=list(range(0, iterations)),
-            execution_provider=self.providers,
-        )
+        loaded = load_smooth_calib_checkpoint(checkpoint_dir) if checkpoint_dir else None
+        if loaded is not None:
+            self.max_vals_per_channel, self.shape_info, self.tensors_to_node = loaded
+            logger.info(
+                "smooth-calib checkpoint: loaded {} activation-max tensor(s) from {}; "
+                "skipping the smoother calibration forwards".format(
+                    len(self.max_vals_per_channel), checkpoint_dir
+                )
+            )
+        else:
+            sq_calibrator = calibrator.Calibrator(
+                self.model,
+                self.dataloader,
+                iterations=list(range(0, iterations)),
+                execution_provider=self.providers,
+            )
 
-        self.max_vals_per_channel, self.shape_info, self.tensors_to_node = sq_calibrator.calib_smooth(
-            op_types, percentile
-        )
+            self.max_vals_per_channel, self.shape_info, self.tensors_to_node = sq_calibrator.calib_smooth(
+                op_types, percentile
+            )
+            if checkpoint_dir:
+                save_smooth_calib_checkpoint(
+                    checkpoint_dir, self.max_vals_per_channel, self.shape_info, self.tensors_to_node
+                )
         for node in self.model.nodes():
             for out in node.output:
                 if (
@@ -658,6 +760,7 @@ class Smoother:
         alpha_step: float = 0.05,
         attn_method: str = "min",
         op_alpha: dict = None,
+        checkpoint_dir=None,
     ):
         """Perform alpha-tuning to obtain layer-wise optimal alpha values and adjust parameters accordingly.
 
@@ -670,6 +773,12 @@ class Smoother:
             op_alpha (dict): optional per-op-type alpha override, {op_type: float | {alpha_min, alpha_max, alpha_step}}.
                 A float pins that op type's alpha (no search, one forward pass saved per node);
                 a dict gives it its own search grid; op types absent here use the global grid.
+            checkpoint_dir (str, optional): when set, alphas.json there is rewritten after
+                EVERY node's grid finishes (best alpha, normalized best loss, and the full
+                per-alpha loss curve), and nodes already recorded in it are restored instead
+                of re-searched. This is what lets an OOM-killed multi-hour search resume from
+                the last completed node. The caller is responsible for not reusing the dir
+                across different models/calibration data/grids.
         """
         logger.info("auto tuning alpha")
 
@@ -706,6 +815,26 @@ class Smoother:
         }
         n_nodes = len(node_spaces)
         total = sum(len(s) for s in node_spaces.values())
+
+        # Resume state: nodes whose grid already completed in a previous run of the SAME
+        # search (the caller keys checkpoint_dir by its full configuration). An entry only
+        # counts when its recorded scales key matches what THIS search would use, so a
+        # checkpoint from a different scales_per_op mode can never be silently misread.
+        ckpt_nodes = load_alpha_checkpoint(checkpoint_dir) if checkpoint_dir else {}
+        cached = {
+            ni[0]
+            for tname, infos in self.tensors_to_node.items()
+            for ni in infos
+            if ckpt_nodes.get(ni[0], {}).get("key") == (ni[0] if self.scales_per_op else tname)
+        }
+        if ckpt_nodes:
+            logger.info(
+                "auto-alpha checkpoint: {} of {} node(s) already searched in {}; "
+                "resuming with the remaining {}".format(
+                    len(cached), n_nodes, checkpoint_dir, n_nodes - len(cached)
+                )
+            )
+
         logger.info(
             "auto-alpha: {} node(s), {} QDQ-loss evaluation(s) over the per-node alpha grids".format(
                 n_nodes, total
@@ -723,7 +852,13 @@ class Smoother:
         self._sq_out_cache = {"node": None, "outputs": None}
         self._sq_subgraph = {"node": None, "session": None, "input": None, "weight": None}
         added_outputs = []
-        if self.model.is_large_model:
+        # When every multi-point node is already checkpointed (or pinned), no QDQ loss is
+        # ever evaluated, so skip the expensive augment save (a full external-data copy of
+        # the model) entirely; the end-of-search reload/cleanup is skipped to match.
+        needs_eval = any(len(space) > 1 and name not in cached for name, space in node_spaces.items())
+        augment_saved = False
+        if self.model.is_large_model and needs_eval:
+            augment_saved = True
             needed, seen = [], set()
             for node_infos in self.tensors_to_node.values():
                 for node_info in node_infos:
@@ -751,11 +886,27 @@ class Smoother:
                     key = node_info[0] if self.scales_per_op else tensor_name
                     node = self.model.get_node(node_info[0])
                     space = node_spaces[node_info[0]]
+                    if node_info[0] in cached:
+                        # Checkpointed by a previous run of this same search: restore the
+                        # best alpha and (for searched nodes) the normalized best loss the
+                        # exclude-worst ranking needs, and skip the whole grid.
+                        entry = ckpt_nodes[node_info[0]]
+                        optimal_alphas[key] = entry["alpha"]
+                        if entry.get("loss") is not None:
+                            self.auto_alpha_losses[node_info[0]] = entry["loss"]
+                        pbar.update(len(space))
+                        continue
                     if len(space) == 1:
                         # Pinned alpha (or a degenerate grid): nothing to compare, so record
                         # it and skip the QDQ loss evaluation entirely. This is the whole cost
                         # saving of pinning an op you already trust (e.g. MatMul=0.5).
                         optimal_alphas[key] = space[0]
+                        if checkpoint_dir:
+                            ckpt_nodes[node_info[0]] = {
+                                "key": key, "op_type": node.op_type, "alpha": space[0],
+                                "loss": None, "losses": {}, "pinned": True,
+                            }
+                            save_alpha_checkpoint(checkpoint_dir, ckpt_nodes)
                         pbar.update(1)
                         continue
                     for alpha in space:
@@ -811,6 +962,18 @@ class Smoother:
                             else None
                         )
                         self.auto_alpha_losses[node_info[0]] = min(loss_alpha.values()) / (ref_sq or 1.0)
+                    if checkpoint_dir:
+                        # Checkpoint after EVERY completed node grid so a crash/OOM loses at
+                        # most one node's work. "losses" keeps the full raw per-alpha curve
+                        # (the search criterion), "loss" the normalized best (the ranking).
+                        ckpt_nodes[node_info[0]] = {
+                            "key": key,
+                            "op_type": node.op_type,
+                            "alpha": optimal_alphas[key],
+                            "loss": self.auto_alpha_losses.get(node_info[0]),
+                            "losses": {"{:g}".format(a): float(l) for a, l in loss_alpha.items()},
+                        }
+                        save_alpha_checkpoint(checkpoint_dir, ckpt_nodes)
         finally:
             pbar.close()
             self._quiet_adjust = False
@@ -822,7 +985,7 @@ class Smoother:
 
         logger.info("auto tuning alpha done")
         self._log_alpha_summary(optimal_alphas)
-        if self.model.is_large_model:
+        if self.model.is_large_model and augment_saved:
 
             onnx.external_data_helper.load_external_data_for_model(
                 self.model.model, os.path.split(self.model.model_path)[0]

--- a/onnx_neural_compressor/algorithms/smoother/core.py
+++ b/onnx_neural_compressor/algorithms/smoother/core.py
@@ -487,6 +487,35 @@ class Smoother:
             scale = np.reshape(self.tensor_scales_info[key], (1, self.tensor_scales_info[key].shape[0]))
         return scale
 
+    def _alpha_grid(self, alpha_min, alpha_max, alpha_step):
+        """Inclusive-of-both-endpoints alpha search grid.
+
+        A request to search alpha_min..alpha_max should try alpha_max itself (np.arange
+        stops just short of its stop value). The +alpha_step/2 nudge pulls alpha_max inside
+        the half-open range without risking a spurious extra step from floating-point
+        rounding. A degenerate grid (alpha_min == alpha_max) collapses to a single value.
+        """
+        return np.arange(alpha_min, alpha_max + alpha_step / 2, alpha_step).tolist()
+
+    def _node_alpha_space(self, node, default_space, op_alpha, alpha_min, alpha_max, alpha_step):
+        """The alpha grid to search for one node, honouring per-op-type overrides.
+
+        op_alpha maps an op type to either a fixed float (pin the alpha, no search: a
+        single-point grid) or a dict of {alpha_min, alpha_max, alpha_step} (a custom grid,
+        each key defaulting to the global value). An op type absent from op_alpha uses the
+        global default_space.
+        """
+        override = (op_alpha or {}).get(node.op_type)
+        if override is None:
+            return default_space
+        if isinstance(override, dict):
+            return self._alpha_grid(
+                override.get("alpha_min", alpha_min),
+                override.get("alpha_max", alpha_max),
+                override.get("alpha_step", alpha_step),
+            )
+        return [float(override)]  # pinned: a single-point grid, evaluated for free below
+
     def _auto_tune_alpha(
         self,
         calib_iter,
@@ -494,6 +523,7 @@ class Smoother:
         alpha_max: float = 0.7,
         alpha_step: float = 0.05,
         attn_method: str = "min",
+        op_alpha: dict = None,
     ):
         """Perform alpha-tuning to obtain layer-wise optimal alpha values and adjust parameters accordingly.
 
@@ -503,25 +533,47 @@ class Smoother:
             alpha_max (float): max value of alpha search space.
             alpha_step (float): step size of alpha search space.
             attn_method (str): criterion method used on attention ops; currently min, max and mean are supported.
+            op_alpha (dict): optional per-op-type alpha override, {op_type: float | {alpha_min, alpha_max, alpha_step}}.
+                A float pins that op type's alpha (no search, one forward pass saved per node);
+                a dict gives it its own search grid; op types absent here use the global grid.
         """
         logger.info("auto tuning alpha")
 
-        # Inclusive of BOTH endpoints: a request to search alpha_min..alpha_max should try
-        # alpha_max itself (np.arange stops just short of its stop value). The +alpha_step/2
-        # nudge pulls alpha_max inside the half-open range without risking a spurious extra
-        # step from floating-point rounding.
-        alpha_space = np.arange(alpha_min, alpha_max + alpha_step / 2, alpha_step).tolist()
+        default_space = self._alpha_grid(alpha_min, alpha_max, alpha_step)
 
         optimal_alphas = {}
 
-        # The (node, alpha) QDQ-loss evaluation is the unit of work and by far the slowest
-        # phase, so drive a tqdm bar over it (live count, rate and ETA). _adjust_weights is
-        # called once per evaluation here, so silence its own bar for the duration.
-        n_nodes = sum(len(infos) for infos in self.tensors_to_node.values())
-        total = n_nodes * len(alpha_space)
+        # Warn for op_alpha keys that match no smoothed node: setting an alpha for an op
+        # type that is not in op_types, or that has no weight to migrate outliers into
+        # (e.g. Slice), is a silent no-op otherwise.
+        smoothed_types = {
+            self.model.get_node(ni[0]).op_type
+            for infos in self.tensors_to_node.values()
+            for ni in infos
+        }
+        for op_type in (op_alpha or {}):
+            if op_type not in smoothed_types:
+                logger.warning(
+                    "op_alpha set for {!r} but no smoothed node has that op type "
+                    "(not in op_types, or it has no weight to smooth); ignored".format(op_type)
+                )
+
+        # Per-node alpha grid (a pinned op collapses to a 1-point grid). The (node, alpha)
+        # QDQ-loss evaluation is the unit of work and by far the slowest phase, so drive a
+        # tqdm bar over it (live count, rate and ETA). _adjust_weights is called once per
+        # evaluation here, so silence its own bar for the duration.
+        node_spaces = {
+            ni[0]: self._node_alpha_space(
+                self.model.get_node(ni[0]), default_space, op_alpha, alpha_min, alpha_max, alpha_step
+            )
+            for infos in self.tensors_to_node.values()
+            for ni in infos
+        }
+        n_nodes = len(node_spaces)
+        total = sum(len(s) for s in node_spaces.values())
         logger.info(
-            "auto-alpha: {} alpha(s) x {} node(s) = {} QDQ-loss evaluation(s)".format(
-                len(alpha_space), n_nodes, total
+            "auto-alpha: {} node(s), {} QDQ-loss evaluation(s) over the per-node alpha grids".format(
+                n_nodes, total
             )
         )
         self._quiet_adjust = True
@@ -562,7 +614,15 @@ class Smoother:
                     loss_alpha = {}
                     key = node_info[0] if self.scales_per_op else tensor_name
                     node = self.model.get_node(node_info[0])
-                    for alpha in alpha_space:
+                    space = node_spaces[node_info[0]]
+                    if len(space) == 1:
+                        # Pinned alpha (or a degenerate grid): nothing to compare, so record
+                        # it and skip the QDQ loss evaluation entirely. This is the whole cost
+                        # saving of pinning an op you already trust (e.g. MatMul=0.5).
+                        optimal_alphas[key] = space[0]
+                        pbar.update(1)
+                        continue
+                    for alpha in space:
                         scale = self._get_smooth_scales(alpha, [key])
                         self._adjust_weights(scale)
                         input_scale = (

--- a/onnx_neural_compressor/algorithms/smoother/core.py
+++ b/onnx_neural_compressor/algorithms/smoother/core.py
@@ -253,10 +253,21 @@ def _make_sub_graph(node, inits, input_data, output_data, weight_name, weight_da
         opset (object): opset of the model
         ir_version (object): ir_version of the model
     """
+    # The sub-graph session is built ONCE per node and then reused for every calibration
+    # sample (see _get_output_loss). Calibration windows may have DIFFERENT sequence
+    # lengths, so the activation input/output must stay shape-dynamic: baking the first
+    # sample's concrete shape here made ORT reject any differently-sized window with
+    # "Got invalid dimensions for input ... Got: N Expected: M". We keep the rank but drop
+    # every dim to dynamic; ORT resolves the real shapes per run() from the fed arrays, so
+    # equal-length calibration is numerically unchanged (the metadata never enters the
+    # MatMul math). Only the weight, fed as a constant-shaped runtime input, keeps its
+    # concrete shape.
+    dynamic_in = [None] * len(input_data.shape)
+    dynamic_out = [None] * len(output_data.shape)
     input = onnx.helper.make_tensor_value_info(
         node.input[0],
         onnx.helper.np_dtype_to_tensor_dtype(input_data.dtype),
-        input_data.shape,
+        dynamic_in,
     )
     weight = onnx.helper.make_tensor_value_info(
         weight_name,
@@ -266,7 +277,7 @@ def _make_sub_graph(node, inits, input_data, output_data, weight_name, weight_da
     output = onnx.helper.make_tensor_value_info(
         node.output[0],
         onnx.helper.np_dtype_to_tensor_dtype(output_data.dtype),
-        output_data.shape,
+        dynamic_out,
     )
     graph = onnx.helper.make_graph([node], "sub_graph", [input, weight], [output], inits)
     model = onnx.helper.make_model(graph, opset_imports=opset)

--- a/onnx_neural_compressor/algorithms/smoother/core.py
+++ b/onnx_neural_compressor/algorithms/smoother/core.py
@@ -192,27 +192,45 @@ def save_smooth_calib_checkpoint(checkpoint_dir, max_vals_per_channel, shape_inf
 
 
 def _alpha_checkpoint_path(checkpoint_dir):
-    return pathlib.Path(checkpoint_dir) / "alphas.json"
+    return pathlib.Path(checkpoint_dir) / "alphas.jsonl"
 
 
 def load_alpha_checkpoint(checkpoint_dir):
     """Per-node auto-alpha results from a previous (possibly crashed) run, as
-    {node_name: {"key", "op_type", "alpha", "loss", "losses"}}. Empty when absent."""
+    {node_name: {"node", "key", "op_type", "alpha", "loss", "losses"}}. Empty when absent.
+
+    The checkpoint is JSONL, one object per line appended as each node's grid completes
+    (append-only beats rewriting the whole file per node: O(1) per node, and a crash can
+    only damage the line being written). A corrupt line, i.e. the half-appended tail of
+    a killed run, is skipped with a warning: that node simply gets re-searched. When a
+    node somehow appears twice, the later line wins."""
     path = _alpha_checkpoint_path(checkpoint_dir)
     if not path.exists():
         return {}
+    nodes = {}
     with open(path) as f:
-        return json.load(f).get("nodes", {})
+        lines = f.readlines()
+    for i, line in enumerate(lines):
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+            nodes[entry["node"]] = entry
+        except (ValueError, KeyError, TypeError):
+            logger.warning(
+                "alpha checkpoint {}: skipping corrupt line {}{}".format(
+                    path, i + 1,
+                    " (a truncated final append from a killed run)" if i == len(lines) - 1 else "",
+                )
+            )
+    return nodes
 
 
-def save_alpha_checkpoint(checkpoint_dir, nodes):
-    """Rewrite the per-node alpha checkpoint (called after EVERY node's grid finishes,
-    so an OOM-killed search resumes from the last completed node). Also the run's
-    human-readable record of which alpha each layer picked and at what QDQ loss."""
-    _atomic_write_bytes(
-        _alpha_checkpoint_path(checkpoint_dir),
-        json.dumps({"nodes": nodes}, indent=1, sort_keys=True).encode(),
-    )
+def append_alpha_checkpoint(checkpoint_dir, entry):
+    """Append one completed node's search result to alphas.jsonl (see
+    load_alpha_checkpoint for the format and the crash-safety argument)."""
+    with open(_alpha_checkpoint_path(checkpoint_dir), "a") as f:
+        f.write(json.dumps(entry, sort_keys=True) + "\n")
 
 
 def _make_sub_graph(node, inits, input_data, output_data, weight_name, weight_data, opset, ir_version):
@@ -350,7 +368,7 @@ class Smoother:
             checkpoint_dir (str | pathlib.Path, optional): directory for resumable
                 intermediates. When set, the smoother-calibration results and the per-node
                 auto-alpha results are written there as they are produced (smooth-calib.npz/
-                .json, alphas.json) and any results already present are LOADED instead of
+                .json, alphas.jsonl) and any results already present are LOADED instead of
                 recomputed, so a crashed/OOM-killed run resumes from the last completed node
                 instead of restarting the whole search. Caller owns cache invalidation: the
                 files carry no model/config fingerprint, so a stale dir must not be reused
@@ -773,12 +791,12 @@ class Smoother:
             op_alpha (dict): optional per-op-type alpha override, {op_type: float | {alpha_min, alpha_max, alpha_step}}.
                 A float pins that op type's alpha (no search, one forward pass saved per node);
                 a dict gives it its own search grid; op types absent here use the global grid.
-            checkpoint_dir (str, optional): when set, alphas.json there is rewritten after
-                EVERY node's grid finishes (best alpha, normalized best loss, and the full
-                per-alpha loss curve), and nodes already recorded in it are restored instead
-                of re-searched. This is what lets an OOM-killed multi-hour search resume from
-                the last completed node. The caller is responsible for not reusing the dir
-                across different models/calibration data/grids.
+            checkpoint_dir (str, optional): when set, one line is appended to alphas.jsonl
+                there after EVERY node's grid finishes (best alpha, normalized best loss,
+                and the full per-alpha loss curve), and nodes already recorded in it are
+                restored instead of re-searched. This is what lets an OOM-killed multi-hour
+                search resume from the last completed node. The caller is responsible for
+                not reusing the dir across different models/calibration data/grids.
         """
         logger.info("auto tuning alpha")
 
@@ -902,11 +920,10 @@ class Smoother:
                         # saving of pinning an op you already trust (e.g. MatMul=0.5).
                         optimal_alphas[key] = space[0]
                         if checkpoint_dir:
-                            ckpt_nodes[node_info[0]] = {
-                                "key": key, "op_type": node.op_type, "alpha": space[0],
-                                "loss": None, "losses": {}, "pinned": True,
-                            }
-                            save_alpha_checkpoint(checkpoint_dir, ckpt_nodes)
+                            append_alpha_checkpoint(checkpoint_dir, {
+                                "node": node_info[0], "key": key, "op_type": node.op_type,
+                                "alpha": space[0], "loss": None, "losses": {}, "pinned": True,
+                            })
                         pbar.update(1)
                         continue
                     for alpha in space:
@@ -966,14 +983,14 @@ class Smoother:
                         # Checkpoint after EVERY completed node grid so a crash/OOM loses at
                         # most one node's work. "losses" keeps the full raw per-alpha curve
                         # (the search criterion), "loss" the normalized best (the ranking).
-                        ckpt_nodes[node_info[0]] = {
+                        append_alpha_checkpoint(checkpoint_dir, {
+                            "node": node_info[0],
                             "key": key,
                             "op_type": node.op_type,
                             "alpha": optimal_alphas[key],
                             "loss": self.auto_alpha_losses.get(node_info[0]),
                             "losses": {"{:g}".format(a): float(l) for a, l in loss_alpha.items()},
-                        }
-                        save_alpha_checkpoint(checkpoint_dir, ckpt_nodes)
+                        })
         finally:
             pbar.close()
             self._quiet_adjust = False

--- a/onnx_neural_compressor/algorithms/smoother/core.py
+++ b/onnx_neural_compressor/algorithms/smoother/core.py
@@ -16,6 +16,7 @@
 import copy
 import os
 import pathlib
+import time
 
 import numpy as np
 import onnx
@@ -26,6 +27,18 @@ from onnx_neural_compressor.algorithms import utility as quant_utils
 from onnx_neural_compressor.algorithms.smoother import calibrator
 
 from typing import List, Union  # isort: skip
+
+
+def _format_duration(seconds):
+    """Format a (possibly fractional) number of seconds as a compact Hh MMm / Mm SSs string."""
+    seconds = int(max(0, seconds))
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    if h:
+        return "{}h{:02d}m".format(h, m)
+    if m:
+        return "{}m{:02d}s".format(m, s)
+    return "{}s".format(s)
 
 
 def _get_quant_dequant_output(model, input_data, output_data, providers):
@@ -107,6 +120,16 @@ class Smoother:
         self.max_vals_per_channel = None
         self.shape_info = None
         self.tensors_to_node = None
+        # Tensors whose per-channel layout the smoother cannot resolve (the activation
+        # max axis and the weight in-channel length disagree, e.g. FastConformer's
+        # relative-position attention MatMuls). They are skipped (left unsmoothed)
+        # rather than crashing _get_smooth_scale on a mismatched broadcast.
+        self.skipped_smooth_tensors = set()
+        # Large-model auto-alpha state: one shared ORIGINAL-weight session exposing
+        # every per-node tensor, plus a per-node activation cache reused across the
+        # alpha grid (the activations are alpha-independent on the large path).
+        self._sq_shared_session = None
+        self._sq_out_cache = {"node": None, "outputs": None}
         self._build_absorb_function()
 
     def transform(
@@ -357,50 +380,84 @@ class Smoother:
             node_name (str): node name
             scale (float): scale of the specific node
             calib_iter (int): iterations
+
+        The calibration ``dataloader`` is rewound before every evaluation: the alpha
+        search drains it once in ``_dump_op_info`` and never rewinds before searching,
+        so without this each evaluation would see an exhausted reader (loss 0) and the
+        per-layer optimal alpha would collapse to ``alpha_min`` for every node.
         """
         node = [i for i in self.model.nodes() if i.name == node_name]
         loss = 0
-        if len(node) > 0:
-            node = node[0]
+        if len(node) == 0:
+            return loss
+        node = node[0]
+
+        if not self.model.is_large_model:
+            # Small model: the session is cheap to rebuild and must be rebuilt every
+            # call (the weight was just scaled for this alpha), so keep doing that and
+            # only add the missing rewind.
             orig_outputs = self.model.output()
             added_tensors = [node.input[0], node.output[0]]
             self.model.add_tensors_to_outputs(added_tensors)
-
-            session = (
-                ort.InferenceSession(self.model.model_path + "_augment.onnx", providers=self.providers)
-                if self.model.is_large_model
-                else ort.InferenceSession(self.model.model.SerializeToString(), providers=self.providers)
-            )
-            base_dir = "" if not self.model.is_large_model else os.path.dirname(self.model.model_path)
-            weight = onnx.numpy_helper.to_array(self.model.get_initializer(node.input[1]), base_dir)
+            session = ort.InferenceSession(self.model.model.SerializeToString(), providers=self.providers)
+            weight = onnx.numpy_helper.to_array(self.model.get_initializer(node.input[1]), "")
             weight_q = quant_utils.qdq_data(weight, 3, True)
-
             self.model.set_initializer(node.input[1], weight_q)
             inits = [self.model.get_initializer(i) for i in node.input if self.model.get_initializer(i) is not None]
 
+            self.dataloader.rewind()
             model = None
-            idx = 1
             while True:
                 inputs = self.dataloader.get_next()
                 if not inputs:
                     break
-                if idx > calib_iter:
-                    break
-
                 outputs = session.run(added_tensors, inputs)
                 if model is None:
                     model = _make_sub_graph(
-                        node,
-                        inits,
-                        outputs[0],
-                        outputs[1],
-                        self.model.model.opset_import,
-                        self.model.model.ir_version,
+                        node, inits, outputs[0], outputs[1],
+                        self.model.model.opset_import, self.model.model.ir_version,
                     )
                 loss += _get_quant_dequant_output(model, outputs[0] * scale, outputs[1], self.providers)
-
             self.model.remove_tensors_from_outputs([i for i in added_tensors if i not in orig_outputs])
             self.model.set_initializer(node.input[1], weight)
+            return loss
+
+        # Large model: the augment file (saved once in _auto_tune_alpha with the
+        # ORIGINAL weights and every per-node in/out tensor exposed as a graph output)
+        # backs ONE shared session whose harvested activations are alpha-independent.
+        # Harvest each node's activations once and cache them across the whole alpha
+        # grid; only the cheap per-alpha QDQ sub-graph depends on the scaled weight.
+        base_dir = os.path.dirname(self.model.model_path)
+        weight = onnx.numpy_helper.to_array(self.model.get_initializer(node.input[1]), base_dir)
+        weight_q = quant_utils.qdq_data(weight, 3, True)
+        self.model.set_initializer(node.input[1], weight_q)
+        inits = [self.model.get_initializer(i) for i in node.input if self.model.get_initializer(i) is not None]
+
+        if self._sq_out_cache.get("node") != node_name:
+            if self._sq_shared_session is None:
+                self._sq_shared_session = ort.InferenceSession(
+                    self.model.model_path + "_augment.onnx", providers=self.providers
+                )
+            fetch = [node.input[0], node.output[0]]
+            self.dataloader.rewind()
+            collected = []
+            while True:
+                inputs = self.dataloader.get_next()
+                if not inputs:
+                    break
+                out0, out1 = self._sq_shared_session.run(fetch, inputs)
+                collected.append((out0, out1))
+            self._sq_out_cache = {"node": node_name, "outputs": collected}
+
+        model = None
+        for out0, out1 in self._sq_out_cache["outputs"]:
+            if model is None:
+                model = _make_sub_graph(
+                    node, inits, out0, out1,
+                    self.model.model.opset_import, self.model.model.ir_version,
+                )
+            loss += _get_quant_dequant_output(model, out0 * scale, out1, self.providers)
+        self.model.set_initializer(node.input[1], weight)
         return loss
 
     def _reshape_scale_for_input(self, tensor, key):
@@ -438,7 +495,39 @@ class Smoother:
         alpha_space = np.arange(alpha_min, alpha_max, alpha_step).tolist()
 
         optimal_alphas = {}
+
+        # Progress / ETA bookkeeping: the (node, alpha) evaluation is the unit of work
+        # and by far the slowest phase, so report a throttled ETA after the first ticks.
+        n_nodes = sum(len(infos) for infos in self.tensors_to_node.values())
+        total = n_nodes * len(alpha_space)
+        done = 0
+        t0 = time.time()
+        last_log = 0.0
+        logger.info(
+            "auto-alpha: {} alpha(s) x {} node(s) = {} QDQ-loss evaluation(s)".format(
+                len(alpha_space), n_nodes, total
+            )
+        )
+
+        # Large-model path: expose every per-node in/out tensor as a graph output
+        # BEFORE saving the augment file, so a single shared original-weight session
+        # can fetch them (the stock augment file lacks them and session.run raises
+        # "Invalid output name"). Those activations are alpha-independent, which is what
+        # makes the per-node cache in _get_output_loss valid.
+        self._sq_shared_session = None
+        self._sq_out_cache = {"node": None, "outputs": None}
+        added_outputs = []
         if self.model.is_large_model:
+            needed, seen = [], set()
+            for node_infos in self.tensors_to_node.values():
+                for node_info in node_infos:
+                    n = self.model.get_node(node_info[0])
+                    for t in (n.input[0], n.output[0]):
+                        if t and t not in seen:
+                            seen.add(t)
+                            needed.append(t)
+            added_outputs = [t for t in needed if t not in set(self.model.output())]
+            self.model.add_tensors_to_outputs(added_outputs)
             onnx.save_model(
                 self.model.model,
                 self.model.model_path + "_augment.onnx",
@@ -449,30 +538,50 @@ class Smoother:
             )
 
         ## Searching optimal alphas
-        for tensor_name, node_infos in self.tensors_to_node.items():
-            for node_info in node_infos:
-                loss_alpha = {}
-                key = node_info[0] if self.scales_per_op else tensor_name
-                node = self.model.get_node(node_info[0])
-                for alpha in alpha_space:
-                    scale = self._get_smooth_scales(alpha, [key])
-                    self._adjust_weights(scale)
-                    input_scale = (
-                        self._reshape_scale_for_input(tensor_name, key)
-                        if not (node.op_type == "Gemm" and quant_utils.is_B_transposed(node))
-                        else self.tensor_scales_info[key]
-                    )
-                    loss = self._get_output_loss(node_info[0], input_scale, calib_iter)
-                    loss_alpha[alpha] = loss
-                    if key not in optimal_alphas:  # Update alpha results
-                        optimal_alphas[key] = alpha
-                    else:
-                        optimal_alphas[key] = (
-                            alpha
-                            if optimal_alphas[key] in loss_alpha and loss < loss_alpha[optimal_alphas[key]]
-                            else optimal_alphas[key]
+        try:
+            for tensor_name, node_infos in self.tensors_to_node.items():
+                for node_info in node_infos:
+                    loss_alpha = {}
+                    key = node_info[0] if self.scales_per_op else tensor_name
+                    node = self.model.get_node(node_info[0])
+                    for alpha in alpha_space:
+                        scale = self._get_smooth_scales(alpha, [key])
+                        self._adjust_weights(scale)
+                        input_scale = (
+                            self._reshape_scale_for_input(tensor_name, key)
+                            if not (node.op_type == "Gemm" and quant_utils.is_B_transposed(node))
+                            else self.tensor_scales_info[key]
                         )
-                    self.recover()
+                        loss = self._get_output_loss(node_info[0], input_scale, calib_iter)
+                        loss_alpha[alpha] = loss
+                        if key not in optimal_alphas:  # Update alpha results
+                            optimal_alphas[key] = alpha
+                        else:
+                            optimal_alphas[key] = (
+                                alpha
+                                if optimal_alphas[key] in loss_alpha and loss < loss_alpha[optimal_alphas[key]]
+                                else optimal_alphas[key]
+                            )
+                        self.recover()
+
+                        done += 1
+                        now = time.time()
+                        if total and (now - last_log >= 15 or done >= total):
+                            last_log = now
+                            elapsed = now - t0
+                            frac = done / total
+                            eta = elapsed / frac - elapsed if frac else 0.0
+                            logger.info(
+                                "auto-alpha: {}/{} ({:.0f}%) elapsed {} ETA ~{}".format(
+                                    done, total, frac * 100, _format_duration(elapsed), _format_duration(eta)
+                                )
+                            )
+        finally:
+            if self.model.is_large_model:
+                self.model.remove_tensors_from_outputs(added_outputs)
+            self._sq_shared_session = None
+            self._sq_out_cache = {"node": None, "outputs": None}
+
         logger.info("auto tuning alpha done")
         if self.model.is_large_model:
 
@@ -535,6 +644,14 @@ class Smoother:
                 specific_alpha = alpha[tensor] if isinstance(alpha, dict) else alpha
                 scales[tensor] = self._get_smooth_scale(weights_stack, specific_alpha, tensor)
 
+        # Drop nodes _get_smooth_scale could not resolve (returned None); downstream
+        # consumers (_insert_smooth_mul_op / _adjust_weights) iterate scales.keys().
+        scales = {k: v for k, v in scales.items() if v is not None}
+        if not target_list and self.skipped_smooth_tensors:
+            logger.info(
+                "SmoothQuant left {} node(s) unsmoothed (unresolvable per-channel layout); "
+                "they fall through to plain static quantization".format(len(self.skipped_smooth_tensors))
+            )
         return scales
 
     def _get_smooth_scale(self, weights, specific_alpha, tensor):
@@ -547,6 +664,16 @@ class Smoother:
         """
         weights = np.abs(weights.reshape(weights.shape[0], -1))
         weights_max = np.amax(weights, axis=-1)
+        if self.max_vals_per_channel[tensor].shape != weights_max.shape:
+            # The per-channel activation max and the weight in-channel length disagree
+            # (the smoother assumes a 3D activation is (batch, seq, in_channel) with the
+            # in-channel LAST, which does not hold for e.g. FastConformer's relative-
+            # position attention MatMuls). The smooth scale could not be broadcast, so
+            # skip this node (it falls through to plain static quantization) instead of
+            # crashing. _insert_smooth_mul_op / _adjust_weights both guard on the key,
+            # so a missing scale is safe.
+            self.skipped_smooth_tensors.add(tensor)
+            return None
         input_power = np.power(self.max_vals_per_channel[tensor], specific_alpha)
         weight_power = np.power(weights_max, 1 - specific_alpha)
         weight_power = np.clip(weight_power, a_min=1e-5, a_max=None)

--- a/onnx_neural_compressor/algorithms/smoother/core.py
+++ b/onnx_neural_compressor/algorithms/smoother/core.py
@@ -93,6 +93,26 @@ def _format_alpha_summary(rows):
     return lines
 
 
+def _to_array_extern_safe(tensor, base_dir):
+    """numpy array of an initializer WITHOUT materializing external bytes into the live proto.
+
+    onnx.numpy_helper.to_array on an external-data tensor calls
+    load_external_data_for_tensor, which ASSIGNS tensor.raw_data in place while leaving
+    data_location EXTERNAL, so every later to_array on the same tensor assigns again.
+    Under protobuf's upb backend (the default) each assignment abandons the previous bytes
+    in the owning ModelProto's arena, which is only freed when the WHOLE proto dies: reads
+    repeated per (node, alpha) evaluation leak weight-sized blocks for the lifetime of the
+    model. Copying the (tiny, metadata-only) external tensor to a throwaway TensorProto and
+    letting to_array materialize THAT keeps the bytes in the throwaway's own arena, freed on
+    return. An in-proto tensor is read as-is (to_array does not mutate it).
+    """
+    if onnx.external_data_helper.uses_external_data(tensor):
+        detached = onnx.TensorProto()
+        detached.CopyFrom(tensor)
+        return onnx.numpy_helper.to_array(detached, base_dir)
+    return onnx.numpy_helper.to_array(tensor, base_dir)
+
+
 def _make_sub_graph(node, inits, input_data, output_data, weight_name, weight_data, opset, ir_version):
     """Build a single-node model whose weight is a runtime INPUT, not a baked initializer.
 
@@ -292,7 +312,7 @@ class Smoother:
                 if key not in self.tensor_scales_info:
                     continue
                 input = node_info[1][1]
-                weight = onnx.numpy_helper.to_array(
+                weight = _to_array_extern_safe(
                     self.model.get_initializer(input),
                     base_dir=os.path.dirname(self.model.model_path) if self.model.model_path is not None else "",
                 )
@@ -488,13 +508,17 @@ class Smoother:
             self._sq_out_cache = {"node": node_name, "outputs": collected}
         return self._sq_out_cache["outputs"]
 
-    def _get_output_loss(self, node_name, scale, calib_iter):
+    def _get_output_loss(self, node_name, scale, calib_iter, weight=None):
         """Get output loss of specific node after inserting QDQ pair.
 
         Args:
             node_name (str): node name
             scale (float): scale of the specific node
             calib_iter (int): iterations
+            weight (np.ndarray, optional): the candidate (already smooth-scaled) weight to
+                score. When given, the node's initializer is not read at all: the large-model
+                auto-alpha search passes the scaled weight directly so the search never has
+                to write it into the proto first (see _scaled_weight on why those writes leak).
 
         The (alpha-dependent) quant-dequant weight is the ONLY thing that changes across the
         alpha grid for a fixed node, so it is fed to the sub-graph session as a runtime input
@@ -511,9 +535,11 @@ class Smoother:
         base_dir = os.path.dirname(self.model.model_path) if self.model.model_path is not None else ""
 
         # The quant-dequant weight is alpha-dependent (the weight was just scaled for this
-        # alpha by _adjust_weights); it is fed to the cached session per call. bias / other
-        # non-weight initializers are alpha-independent and stay baked into the sub-graph.
-        weight = onnx.numpy_helper.to_array(self.model.get_initializer(node.input[1]), base_dir)
+        # alpha, either in-proto by _adjust_weights or passed in directly); it is fed to the
+        # cached session per call. bias / other non-weight initializers are alpha-independent
+        # and stay baked into the sub-graph.
+        if weight is None:
+            weight = _to_array_extern_safe(self.model.get_initializer(node.input[1]), base_dir)
         weight_q = quant_utils.qdq_data(weight, 3, True)
         extra_inits = [
             self.model.get_initializer(i)
@@ -696,13 +722,33 @@ class Smoother:
                         continue
                     for alpha in space:
                         scale = self._get_smooth_scales(alpha, [key])
-                        self._adjust_weights(scale)
+                        if self.model.is_large_model:
+                            # Score the candidate WITHOUT writing the proto. The historical
+                            # flow (_adjust_weights then recover) rewrote this node's weight
+                            # initializer twice per evaluation; under protobuf's upb backend
+                            # each rewrite permanently grows the ModelProto's arena (old
+                            # bytes are only freed when the whole proto dies), so the
+                            # retained memory scaled with n_nodes x n_alphas and survived
+                            # into static calibration: a 0.1-step grid OOMed where a
+                            # 0.2-step grid fit. The references are alpha-independent here
+                            # (original-weight augment session), so nothing else needs the
+                            # adjusted weight: compute it in numpy and feed it directly.
+                            # Bonus: each alpha now scales the PRISTINE on-disk weight
+                            # instead of one that drifted through k scale/unscale roundtrips.
+                            cand_weight, inv_scale = self._scaled_weight(node_info[1][1], key, scale)
+                            self.tensor_scales_info[key] = inv_scale
+                        else:
+                            # Small path: the reference activations are recomputed per call
+                            # from the live model, so the weight must really be adjusted
+                            # in-proto (and recovered below) to keep the loss semantics.
+                            cand_weight = None
+                            self._adjust_weights(scale)
                         input_scale = (
                             self._reshape_scale_for_input(tensor_name, key)
                             if not (node.op_type == "Gemm" and quant_utils.is_B_transposed(node))
                             else self.tensor_scales_info[key]
                         )
-                        loss = self._get_output_loss(node_info[0], input_scale, calib_iter)
+                        loss = self._get_output_loss(node_info[0], input_scale, calib_iter, weight=cand_weight)
                         loss_alpha[alpha] = loss
                         if key not in optimal_alphas:  # Update alpha results
                             optimal_alphas[key] = alpha
@@ -712,7 +758,10 @@ class Smoother:
                                 if optimal_alphas[key] in loss_alpha and loss < loss_alpha[optimal_alphas[key]]
                                 else optimal_alphas[key]
                             )
-                        self.recover()
+                        if self.model.is_large_model:
+                            self.tensor_scales_info = {}
+                        else:
+                            self.recover()
                         pbar.update(1)
         finally:
             pbar.close()
@@ -776,7 +825,7 @@ class Smoother:
                     node = self.model.get_node_by_weight(node_info[1][1])
                     if len(target_list) > 0 and node_info[0] not in target_list:
                         continue
-                    weight = onnx.numpy_helper.to_array(
+                    weight = _to_array_extern_safe(
                         self.model.get_initializer(node_info[1][1]),
                         base_dir=os.path.dirname(self.model.model_path) if self.model.model_path is not None else "",
                     )
@@ -792,7 +841,7 @@ class Smoother:
                 weights_in_channel_max = []
                 for node_info in nodes:
                     node = self.model.get_node_by_weight(node_info[1][1])
-                    weight = onnx.numpy_helper.to_array(
+                    weight = _to_array_extern_safe(
                         self.model.get_initializer(node_info[1][1]),
                         base_dir=os.path.dirname(self.model.model_path) if self.model.model_path is not None else "",
                     )
@@ -891,6 +940,42 @@ class Smoother:
                 for node_info in self.tensors_to_node[key]:
                     self.replace_input.append([self.model.get_node(node_info[0]), key, mul_output_name])
 
+    def _scaled_weight(self, input_name, key, scales):
+        """Scaled candidate weight for one node, computed WITHOUT writing the model proto.
+
+        Returns (new_weight, inv_scale): the weight with the smooth scale folded in, plus
+        the reshaped inverse scale that belongs in ``tensor_scales_info[key]`` (what
+        _reshape_scale_for_input and recover() consume). _adjust_weights delegates here
+        for its per-node math so the two can never drift apart; the auto-alpha search
+        calls it directly to score an alpha without mutating any initializer (under
+        protobuf's upb backend, rewriting an initializer of a long-lived ModelProto
+        abandons the old bytes in the proto's arena until the WHOLE model dies, so
+        per-evaluation rewrites leak memory proportional to the alpha-grid size).
+        """
+        node = self.model.get_node_by_weight(input_name)
+        weight = _to_array_extern_safe(
+            self.model.get_initializer(input_name),
+            base_dir=os.path.dirname(self.model.model_path) if self.model.model_path is not None else "",
+        )
+        if len(weight.shape) == 2:
+            scale = (
+                np.expand_dims(scales[key], axis=0)
+                if node.op_type == "Gemm" and quant_utils.is_B_transposed(node)
+                else np.expand_dims(scales[key], axis=-1)
+            )
+        elif len(weight.shape) == 4:  # TODO need to check conv
+            if (
+                weight.shape[1] == 1
+                and "group" in [i.name for i in node.attribute]
+                and [i for i in node.attribute if i.name == "group"][0].i > 1
+            ):
+                scale = np.reshape(scales[key], (-1, 1, 1, 1))
+            else:
+                scale = np.reshape(scales[key], (1, -1, 1, 1))
+        else:
+            assert False, "not support"
+        return weight * scale, 1.0 / scale
+
     def _adjust_weights(self, scales):
         """Adjust the weights with scale.
 
@@ -909,32 +994,8 @@ class Smoother:
                 if key not in scales:
                     continue
                 input = node_info[1][1]
-                node = self.model.get_node_by_weight(input)
-                weight = onnx.numpy_helper.to_array(
-                    self.model.get_initializer(input),
-                    base_dir=os.path.dirname(self.model.model_path) if self.model.model_path is not None else "",
-                )
-                if len(weight.shape) == 2:
-                    scale = (
-                        np.expand_dims(scales[key], axis=0)
-                        if node.op_type == "Gemm" and quant_utils.is_B_transposed(node)
-                        else np.expand_dims(scales[key], axis=-1)
-                    )
-                    new_weight = weight * scale
-                elif len(weight.shape) == 4:  # TODO need to check conv
-                    node = self.model.get_node_by_weight(input)
-                    if (
-                        weight.shape[1] == 1
-                        and "group" in [i.name for i in node.attribute]
-                        and [i for i in node.attribute if i.name == "group"][0].i > 1
-                    ):
-                        scale = np.reshape(scales[key], (-1, 1, 1, 1))
-                    else:
-                        scale = np.reshape(scales[key], (1, -1, 1, 1))
-                    new_weight = weight * scale
-                else:
-                    assert False, "not support"
-                self.tensor_scales_info[key] = 1.0 / scale
+                new_weight, inv_scale = self._scaled_weight(input, key, scales)
+                self.tensor_scales_info[key] = inv_scale
 
                 new_tensor = onnx.numpy_helper.from_array(new_weight, input)
                 self.model.get_initializer(input).CopyFrom(new_tensor)

--- a/onnx_neural_compressor/algorithms/smoother/core.py
+++ b/onnx_neural_compressor/algorithms/smoother/core.py
@@ -64,6 +64,31 @@ def _qdq_loss(session, input_name, input_data, output_data):
     return np.sum(np.abs(output_data - preds) ** 2)
 
 
+def _format_alpha_summary(rows):
+    """Render the per-layer alpha the auto-search settled on, grouped by op type.
+
+    rows: list of (node_name, op_type, alpha). Returns a list of log lines: a per-op-type
+    value histogram (how many layers picked each alpha, answering "did everything just
+    land on the default, or did the search actually move layers?") followed by the full
+    per-layer list so a diverging layer is identifiable by name. Pure (no logger) so it is
+    unit-testable. Alphas are formatted with %g so 0.5 reads "0.5", 0.55 reads "0.55".
+    """
+    lines = ["auto-alpha: per-layer alpha chosen ({} smoothed node(s))".format(len(rows))]
+    by_type = {}
+    for name, op_type, alpha in rows:
+        by_type.setdefault(op_type, []).append((name, float(alpha)))
+    for op_type in sorted(by_type):
+        items = by_type[op_type]
+        hist = {}
+        for _, alpha in items:
+            hist[round(alpha, 4)] = hist.get(round(alpha, 4), 0) + 1
+        summary = ", ".join("{:g}x{}".format(a, hist[a]) for a in sorted(hist))
+        lines.append("  {} ({} node(s)): {}".format(op_type, len(items), summary))
+        for name, alpha in items:
+            lines.append("    {} -> {:g}".format(name, alpha))
+    return lines
+
+
 def _make_sub_graph(node, inits, input_data, output_data, opset, ir_version):
     """Build a model with the specific node.
 
@@ -660,6 +685,7 @@ class Smoother:
             self._sq_out_cache = {"node": None, "outputs": None}
 
         logger.info("auto tuning alpha done")
+        self._log_alpha_summary(optimal_alphas)
         if self.model.is_large_model:
 
             onnx.external_data_helper.load_external_data_for_model(
@@ -668,6 +694,27 @@ class Smoother:
             os.remove(self.model.model_path + "_augment.onnx")
             os.remove(os.path.join(os.path.dirname(self.model.model_path), "weights.pb"))
         return optimal_alphas
+
+    def _log_alpha_summary(self, optimal_alphas):
+        """Log which alpha the search actually picked for every smoothed layer.
+
+        Tells you at a glance whether the default just won everywhere or whether the
+        per-layer search genuinely moved layers. optimal_alphas is keyed by node name
+        when scales_per_op, else by the shared input tensor feeding several nodes; both
+        are expanded to one (node, op_type, alpha) row so the report is always per layer.
+        """
+        rows = []
+        for tensor_name, node_infos in self.tensors_to_node.items():
+            for node_info in node_infos:
+                key = node_info[0] if self.scales_per_op else tensor_name
+                if key not in optimal_alphas:
+                    continue
+                node = self.model.get_node(node_info[0])
+                rows.append((node_info[0], node.op_type, optimal_alphas[key]))
+        if not rows:
+            return
+        for line in _format_alpha_summary(rows):
+            logger.info(line)
 
     def _get_smooth_scales(self, alpha, target_list=[]):
         """Get the smooth scales for.

--- a/onnx_neural_compressor/algorithms/smoother/core.py
+++ b/onnx_neural_compressor/algorithms/smoother/core.py
@@ -375,9 +375,9 @@ class Smoother:
                 files carry no model/config fingerprint, so a stale dir must not be reused
                 across different models, calibration data, or alpha grids.
             checkpoint_interval_sec (float, optional): minimum seconds between the
-                calibrator's MID-pass per-sample activation dumps (smooth-acts/); they are
-                activation-sized, so a fast pass writes nothing while a slow pass loses at
-                most this much work to a crash. Defaults to 1200 (20 minutes).
+                calibrator's MID-pass state dumps (smooth-stream.npz, small); a run killed
+                inside the calibration pass loses at most this much work to a crash.
+                Defaults to 1200 (20 minutes).
 
         Returns:
             onnx.ModelProto: A FP32 model with the same architecture as the orig model
@@ -427,7 +427,7 @@ class Smoother:
             iterations (int): iterations
             checkpoint_dir (str, optional): when set, load the calibration results from
                 there if present (skipping every forward pass), else compute and save them.
-                The calibrator additionally dumps its per-sample activations in there
+                The calibrator additionally dumps its streaming-reducer state in there
                 (time-gated) so even a run killed MID-pass resumes from the last dumped
                 sample instead of redoing every forward.
             checkpoint_interval_sec (float): minimum seconds between those mid-pass dumps
@@ -441,9 +441,9 @@ class Smoother:
                     len(self.max_vals_per_channel), checkpoint_dir
                 )
             )
-            # Partial per-sample dumps from the run that crashed before finishing the
-            # full checkpoint are superseded by it now; drop the dead weight.
-            calibrator.clear_acts_checkpoint(checkpoint_dir)
+            # Mid-pass state from the run that crashed before finishing the full
+            # checkpoint is superseded by it now; drop it.
+            calibrator.clear_stream_checkpoint(checkpoint_dir)
         else:
             sq_calibrator = calibrator.Calibrator(
                 self.model,
@@ -464,7 +464,7 @@ class Smoother:
                 save_smooth_calib_checkpoint(
                     checkpoint_dir, self.max_vals_per_channel, self.shape_info, self.tensors_to_node
                 )
-                calibrator.clear_acts_checkpoint(checkpoint_dir)
+                calibrator.clear_stream_checkpoint(checkpoint_dir)
         for node in self.model.nodes():
             for out in node.output:
                 if (

--- a/onnx_neural_compressor/algorithms/smoother/core.py
+++ b/onnx_neural_compressor/algorithms/smoother/core.py
@@ -345,6 +345,7 @@ class Smoother:
         calib_iter: int = 100,
         auto_alpha_args: dict = {"alpha_min": 0.3, "alpha_max": 0.7, "alpha_step": 0.05, "attn_method": "min"},
         checkpoint_dir: Union[str, pathlib.Path, None] = None,
+        checkpoint_interval_sec: float = 1200,
         *args,
         **kwargs
     ):
@@ -373,6 +374,10 @@ class Smoother:
                 instead of restarting the whole search. Caller owns cache invalidation: the
                 files carry no model/config fingerprint, so a stale dir must not be reused
                 across different models, calibration data, or alpha grids.
+            checkpoint_interval_sec (float, optional): minimum seconds between the
+                calibrator's MID-pass per-sample activation dumps (smooth-acts/); they are
+                activation-sized, so a fast pass writes nothing while a slow pass loses at
+                most this much work to a crash. Defaults to 1200 (20 minutes).
 
         Returns:
             onnx.ModelProto: A FP32 model with the same architecture as the orig model
@@ -389,7 +394,8 @@ class Smoother:
                 alpha = 1.0
                 logger.warning("reset alpha to 1.0 ")
 
-        self._dump_op_info(percentile, op_types, calib_iter, checkpoint_dir=checkpoint_dir)
+        self._dump_op_info(percentile, op_types, calib_iter, checkpoint_dir=checkpoint_dir,
+                           checkpoint_interval_sec=checkpoint_interval_sec)
 
         if alpha == "auto":
             alpha = self._auto_tune_alpha(calib_iter, checkpoint_dir=checkpoint_dir, **auto_alpha_args)
@@ -411,7 +417,8 @@ class Smoother:
         self.model.remove_unused_nodes()
         return self.model.model
 
-    def _dump_op_info(self, percentile, op_types, iterations, checkpoint_dir=None):
+    def _dump_op_info(self, percentile, op_types, iterations, checkpoint_dir=None,
+                      checkpoint_interval_sec=1200):
         """Dump op info for smooth quant.
 
         Args:
@@ -419,7 +426,11 @@ class Smoother:
             op_types (list): the op type to be smooth quantized
             iterations (int): iterations
             checkpoint_dir (str, optional): when set, load the calibration results from
-                there if present (skipping every forward pass), else compute and save them
+                there if present (skipping every forward pass), else compute and save them.
+                The calibrator additionally dumps its per-sample activations in there
+                (time-gated) so even a run killed MID-pass resumes from the last dumped
+                sample instead of redoing every forward.
+            checkpoint_interval_sec (float): minimum seconds between those mid-pass dumps
         """
         loaded = load_smooth_calib_checkpoint(checkpoint_dir) if checkpoint_dir else None
         if loaded is not None:
@@ -430,6 +441,9 @@ class Smoother:
                     len(self.max_vals_per_channel), checkpoint_dir
                 )
             )
+            # Partial per-sample dumps from the run that crashed before finishing the
+            # full checkpoint are superseded by it now; drop the dead weight.
+            calibrator.clear_acts_checkpoint(checkpoint_dir)
         else:
             sq_calibrator = calibrator.Calibrator(
                 self.model,
@@ -439,6 +453,8 @@ class Smoother:
                 # `execution_provider=`, which fell into **kwargs and silently pinned
                 # every smoother-calibration forward to the CPU even on a CUDA run.
                 providers=self.providers,
+                checkpoint_dir=checkpoint_dir,
+                checkpoint_interval_sec=checkpoint_interval_sec,
             )
 
             self.max_vals_per_channel, self.shape_info, self.tensors_to_node = sq_calibrator.calib_smooth(
@@ -448,6 +464,7 @@ class Smoother:
                 save_smooth_calib_checkpoint(
                     checkpoint_dir, self.max_vals_per_channel, self.shape_info, self.tensors_to_node
                 )
+                calibrator.clear_acts_checkpoint(checkpoint_dir)
         for node in self.model.nodes():
             for out in node.output:
                 if (

--- a/onnx_neural_compressor/algorithms/smoother/core.py
+++ b/onnx_neural_compressor/algorithms/smoother/core.py
@@ -435,7 +435,10 @@ class Smoother:
                 self.model,
                 self.dataloader,
                 iterations=list(range(0, iterations)),
-                execution_provider=self.providers,
+                # NOTE: the ctor parameter is `providers`; the historical call passed
+                # `execution_provider=`, which fell into **kwargs and silently pinned
+                # every smoother-calibration forward to the CPU even on a CUDA run.
+                providers=self.providers,
             )
 
             self.max_vals_per_channel, self.shape_info, self.tensors_to_node = sq_calibrator.calib_smooth(

--- a/onnx_neural_compressor/algorithms/smoother/core.py
+++ b/onnx_neural_compressor/algorithms/smoother/core.py
@@ -506,7 +506,11 @@ class Smoother:
         """
         logger.info("auto tuning alpha")
 
-        alpha_space = np.arange(alpha_min, alpha_max, alpha_step).tolist()
+        # Inclusive of BOTH endpoints: a request to search alpha_min..alpha_max should try
+        # alpha_max itself (np.arange stops just short of its stop value). The +alpha_step/2
+        # nudge pulls alpha_max inside the half-open range without risking a spurious extra
+        # step from floating-point rounding.
+        alpha_space = np.arange(alpha_min, alpha_max + alpha_step / 2, alpha_step).tolist()
 
         optimal_alphas = {}
 

--- a/onnx_neural_compressor/algorithms/smoother/core.py
+++ b/onnx_neural_compressor/algorithms/smoother/core.py
@@ -113,6 +113,31 @@ def _to_array_extern_safe(tensor, base_dir):
     return onnx.numpy_helper.to_array(tensor, base_dir)
 
 
+def select_worst_nodes(losses, spec):
+    """Pick the nodes whose BEST achievable QDQ loss is highest, i.e. the layers the
+    alpha search could fix least; excluding them from quantization (keeping them fp32)
+    is sensitivity-based mixed precision.
+
+    losses: {node_name: normalized best loss} as recorded by _auto_tune_alpha in
+    ``Smoother.auto_alpha_losses``. spec: an int n (>= 1) selects the n worst nodes,
+    a float f in (0, 1) selects the worst round(f * len(losses)) nodes (at least 1).
+    Ties are broken by node name so the selection is deterministic. Pure and
+    unit-testable; the SmoothQuantExcludeWorst plumbing lives in smooth_quant_entry.
+    """
+    if isinstance(spec, bool) or not isinstance(spec, (int, float)):
+        raise ValueError("exclude-worst spec must be an int >= 1 or a float in (0, 1), got {!r}".format(spec))
+    if isinstance(spec, float):
+        if not 0.0 < spec < 1.0:
+            raise ValueError("a fractional exclude-worst spec must be in (0, 1), got {!r}".format(spec))
+        count = max(1, round(len(losses) * spec))
+    else:
+        if spec < 1:
+            raise ValueError("an integer exclude-worst spec must be >= 1, got {!r}".format(spec))
+        count = min(spec, len(losses))
+    ranked = sorted(losses, key=lambda name: (-losses[name], name))
+    return ranked[:count]
+
+
 def _make_sub_graph(node, inits, input_data, output_data, weight_name, weight_data, opset, ir_version):
     """Build a single-node model whose weight is a runtime INPUT, not a baked initializer.
 
@@ -204,6 +229,11 @@ class Smoother:
         # fed as a runtime input, so the session is alpha-independent). Built once per node
         # instead of once per (node, alpha) -- see _make_sub_graph / _get_output_loss.
         self._sq_subgraph = {"node": None, "session": None, "input": None, "weight": None}
+        # Per-node best QDQ loss recorded by the auto-alpha search, normalized by each
+        # node's reference-output energy so values are comparable across nodes. Feeds
+        # select_worst_nodes / SmoothQuantExcludeWorst. Empty when alpha is a fixed
+        # float (no search) or for nodes pinned to a 1-point grid (never evaluated).
+        self.auto_alpha_losses = {}
         # Quiets _adjust_weights' own tqdm bar while it is called once per (node, alpha)
         # inside the auto-alpha search (where the single auto-alpha bar is the real signal);
         # the final single full-model apply in transform() re-enables it.
@@ -562,6 +592,13 @@ class Smoother:
                 "session": _build_qdq_session(sub_model, self.providers),
                 "input": sub_model.graph.input[0].name,
                 "weight": node.input[1],
+                # Reference-output energy of this node, the normalizer that makes
+                # per-node best losses comparable across nodes (the raw sum-of-squares
+                # loss scales with each node's output magnitude). Computed once per
+                # node alongside the session; on the small path the references drift
+                # slightly with the in-proto weight of the alpha under evaluation,
+                # which is fine for a ranking.
+                "ref_sq": float(sum((s[1].astype(np.float64) ** 2).sum() for s in samples)),
             }
         sub_sess = self._sq_subgraph["session"]
         sub_input = self._sq_subgraph["input"]
@@ -639,6 +676,7 @@ class Smoother:
         default_space = self._alpha_grid(alpha_min, alpha_max, alpha_step)
 
         optimal_alphas = {}
+        self.auto_alpha_losses = {}
 
         # Warn for op_alpha keys that match no smoothed node: setting an alpha for an op
         # type that is not in op_types, or that has no weight to migrate outliers into
@@ -763,6 +801,16 @@ class Smoother:
                         else:
                             self.recover()
                         pbar.update(1)
+                    if loss_alpha:
+                        # The node's best achievable loss, normalized by its reference-output
+                        # energy (cached on _sq_subgraph, still holding THIS node right after
+                        # its grid): the sensitivity ranking behind SmoothQuantExcludeWorst.
+                        ref_sq = (
+                            self._sq_subgraph.get("ref_sq")
+                            if self._sq_subgraph.get("node") == node_info[0]
+                            else None
+                        )
+                        self.auto_alpha_losses[node_info[0]] = min(loss_alpha.values()) / (ref_sq or 1.0)
         finally:
             pbar.close()
             self._quiet_adjust = False

--- a/onnx_neural_compressor/algorithms/smoother/core.py
+++ b/onnx_neural_compressor/algorithms/smoother/core.py
@@ -16,29 +16,31 @@
 import copy
 import os
 import pathlib
-import time
 
 import numpy as np
 import onnx
 import onnxruntime as ort
+import tqdm
 
-from onnx_neural_compressor import data_reader, logger, onnx_model, utility
+from onnx_neural_compressor import data_reader, logger, onnx_model
 from onnx_neural_compressor.algorithms import utility as quant_utils
 from onnx_neural_compressor.algorithms.smoother import calibrator
 
 from typing import List, Union  # isort: skip
 
 
-def _format_duration(seconds):
-    """Format a (possibly fractional) number of seconds as a compact Hh MMm / Mm SSs string."""
-    seconds = int(max(0, seconds))
-    h, rem = divmod(seconds, 3600)
-    m, s = divmod(rem, 60)
-    if h:
-        return "{}h{:02d}m".format(h, m)
-    if m:
-        return "{}m{:02d}s".format(m, s)
-    return "{}s".format(s)
+def _quiet_session_options():
+    """ORT SessionOptions that silence the per-build 'Removing initializer' warnings.
+
+    The smoother rebuilds an InferenceSession for every (node, alpha) evaluation in the
+    auto-alpha search; each build logs a WARNING for every pruned ``*_smooth_scale``
+    initializer (graph.cc CleanUnusedInitializersAndNodeArgs), flooding the console with
+    thousands of identical lines. Severity 3 keeps errors and fatals, drops the warnings;
+    the tqdm progress bar then stays the single readable signal of what is happening.
+    """
+    so = ort.SessionOptions()
+    so.log_severity_level = 3
+    return so
 
 
 def _get_quant_dequant_output(model, input_data, output_data, providers):
@@ -51,7 +53,9 @@ def _get_quant_dequant_output(model, input_data, output_data, providers):
         providers (list): execution provider
     """
     input_data = quant_utils.qdq_data(input_data, 2, False)
-    sess = ort.InferenceSession(model.SerializeToString(), providers=providers)
+    sess = ort.InferenceSession(
+        model.SerializeToString(), sess_options=_quiet_session_options(), providers=providers
+    )
     preds = sess.run(None, {model.graph.input[0].name: input_data})
     loss = np.sum(np.abs(output_data - preds) ** 2)
     return loss
@@ -130,6 +134,10 @@ class Smoother:
         # alpha grid (the activations are alpha-independent on the large path).
         self._sq_shared_session = None
         self._sq_out_cache = {"node": None, "outputs": None}
+        # Quiets _adjust_weights' own tqdm bar while it is called once per (node, alpha)
+        # inside the auto-alpha search (where the single auto-alpha bar is the real signal);
+        # the final single full-model apply in transform() re-enables it.
+        self._quiet_adjust = False
         self._build_absorb_function()
 
     def transform(
@@ -399,7 +407,11 @@ class Smoother:
             orig_outputs = self.model.output()
             added_tensors = [node.input[0], node.output[0]]
             self.model.add_tensors_to_outputs(added_tensors)
-            session = ort.InferenceSession(self.model.model.SerializeToString(), providers=self.providers)
+            session = ort.InferenceSession(
+                self.model.model.SerializeToString(),
+                sess_options=_quiet_session_options(),
+                providers=self.providers,
+            )
             weight = onnx.numpy_helper.to_array(self.model.get_initializer(node.input[1]), "")
             weight_q = quant_utils.qdq_data(weight, 3, True)
             self.model.set_initializer(node.input[1], weight_q)
@@ -436,7 +448,9 @@ class Smoother:
         if self._sq_out_cache.get("node") != node_name:
             if self._sq_shared_session is None:
                 self._sq_shared_session = ort.InferenceSession(
-                    self.model.model_path + "_augment.onnx", providers=self.providers
+                    self.model.model_path + "_augment.onnx",
+                    sess_options=_quiet_session_options(),
+                    providers=self.providers,
                 )
             fetch = [node.input[0], node.output[0]]
             self.dataloader.rewind()
@@ -496,18 +510,18 @@ class Smoother:
 
         optimal_alphas = {}
 
-        # Progress / ETA bookkeeping: the (node, alpha) evaluation is the unit of work
-        # and by far the slowest phase, so report a throttled ETA after the first ticks.
+        # The (node, alpha) QDQ-loss evaluation is the unit of work and by far the slowest
+        # phase, so drive a tqdm bar over it (live count, rate and ETA). _adjust_weights is
+        # called once per evaluation here, so silence its own bar for the duration.
         n_nodes = sum(len(infos) for infos in self.tensors_to_node.values())
         total = n_nodes * len(alpha_space)
-        done = 0
-        t0 = time.time()
-        last_log = 0.0
         logger.info(
             "auto-alpha: {} alpha(s) x {} node(s) = {} QDQ-loss evaluation(s)".format(
                 len(alpha_space), n_nodes, total
             )
         )
+        self._quiet_adjust = True
+        pbar = tqdm.tqdm(total=total, desc="SmoothQuant auto-alpha", unit="eval", leave=True)
 
         # Large-model path: expose every per-node in/out tensor as a graph output
         # BEFORE saving the augment file, so a single shared original-weight session
@@ -563,20 +577,10 @@ class Smoother:
                                 else optimal_alphas[key]
                             )
                         self.recover()
-
-                        done += 1
-                        now = time.time()
-                        if total and (now - last_log >= 15 or done >= total):
-                            last_log = now
-                            elapsed = now - t0
-                            frac = done / total
-                            eta = elapsed / frac - elapsed if frac else 0.0
-                            logger.info(
-                                "auto-alpha: {}/{} ({:.0f}%) elapsed {} ETA ~{}".format(
-                                    done, total, frac * 100, _format_duration(elapsed), _format_duration(eta)
-                                )
-                            )
+                        pbar.update(1)
         finally:
+            pbar.close()
+            self._quiet_adjust = False
             if self.model.is_large_model:
                 self.model.remove_tensors_from_outputs(added_outputs)
             self._sq_shared_session = None
@@ -734,8 +738,13 @@ class Smoother:
         Args:
             scales (dict): The input scales
         """
-        for idx, (tensor_name, nodes) in enumerate(self.tensors_to_node.items()):
-            utility.simple_progress_bar(len(self.tensors_to_node), idx + 1)
+        for tensor_name, nodes in tqdm.tqdm(
+            self.tensors_to_node.items(),
+            desc="SmoothQuant: folding scales into weights",
+            unit="tensor",
+            disable=self._quiet_adjust,
+            leave=False,
+        ):
             for node_info in nodes:
                 key = node_info[0] if self.scales_per_op else tensor_name
                 if key not in scales:

--- a/onnx_neural_compressor/algorithms/utility.py
+++ b/onnx_neural_compressor/algorithms/utility.py
@@ -38,6 +38,36 @@ ms_domain = "com.microsoft"
 QUANT_OP_NAME_SUFFIX = "_quant"
 
 
+def conservative_session_resources(sess_options, providers):
+    """Memory-conservative ORT settings for the dump/calibration sessions.
+
+    The augmented dump graphs return hundreds of activation tensors per forward
+    pass, and ORT's BFC arenas both grow ahead of demand (power-of-two extends)
+    and never give memory back, so these sessions can hold several GB beyond
+    their working set; on a loaded host (or a small GPU) that slack is the
+    difference between fitting and a BFCArena "Failed to allocate memory" abort
+    mid-calibration. These sessions only run a handful of forward passes, so
+    trading allocator speed for a demand-sized footprint costs nothing: disable
+    the CPU arena and make any CUDA arena grow only by what is actually
+    requested (with the heuristic cuDNN algo search instead of EXHAUSTIVE's
+    large transient workspaces).
+
+    Mutates sess_options in place and returns the providers list to pass to
+    InferenceSession (CUDA entries become (name, options) tuples).
+    """
+    sess_options.enable_cpu_mem_arena = False
+    out = []
+    for provider in providers:
+        if provider == "CUDAExecutionProvider":
+            out.append((provider, {
+                "arena_extend_strategy": "kSameAsRequested",
+                "cudnn_conv_algo_search": "HEURISTIC",
+            }))
+        else:
+            out.append(provider)
+    return out
+
+
 def attribute_to_kwarg(attribute):
     """Convert attribute to kwarg format for use with onnx.helper.make_node."""
     attribute_mapping = {

--- a/onnx_neural_compressor/algorithms/utility.py
+++ b/onnx_neural_compressor/algorithms/utility.py
@@ -847,13 +847,44 @@ class QuantizedInitializer:
         self.qType = qType
 
 
-def dump_model_op_stats(model, quantize_config, fp32_op_list):
+# Census buckets for dump_model_op_stats. A weight-bearing op is directly
+# quantizable on its own (given calibration data) only when its weight (input[1])
+# is an initializer: a weightless MatMul (e.g. attention Q@K^T, probs@V) is only
+# converted when an int8 region already reaches its inputs. The pass-through ops
+# carry no weights at all and only ever BECOME int8 when they sit inside an int8
+# region (the quantizer routes the int8 tensor through them); an fp32 one is not
+# directly actionable either.
+WEIGHT_BEARING_OPS = ("Conv", "FusedConv", "Gemm", "MatMul")
+PASS_THROUGH_OPS = (
+    "Reshape", "Transpose", "Squeeze", "Unsqueeze", "Flatten", "Expand", "Slice",
+    "SpaceToDepth", "DepthToSpace", "Upsample", "Tile", "CenterCropPad",
+    "Concat", "Split", "Pad", "MaxPool", "AveragePool", "GlobalAveragePool", "Resize",
+)
+# Always shown in the census even when not requested for quantization: these glue
+# ops decide whether an int8 region can reach the weightless attention MatMuls, so
+# their counts matter when reading the MatMul row.
+ALWAYS_DUMP_OP_TYPES = ("Reshape", "Transpose")
+
+INT8_COL = "INT8"
+FP32_QUANTIZABLE_COL = "FP32 quantizable"
+FP32_BLOCKED_COL = "FP32 needs-int8-input"
+
+
+def collect_op_quant_stats(model, op_types):
+    """Per-op-type census of a quantized model, splitting fp32 leftovers by cause.
+
+    Returns an ordered dict op_type -> {INT8, FP32 quantizable, FP32 needs-int8-input}
+    counts over op_types (plus ALWAYS_DUMP_OP_TYPES and the Q/DQ ops). "FP32
+    quantizable" nodes could be quantized directly on a re-run (they were excluded or
+    fell back); "FP32 needs-int8-input" nodes cannot: they are weightless (a dynamic
+    MatMul) or pass-through ops, which only turn int8 when the surrounding region does.
+    """
     qdq_ops = ["QuantizeLinear", "DequantizeLinear", "DynamicQuantizeLinear"]
+    cols = (INT8_COL, FP32_QUANTIZABLE_COL, FP32_BLOCKED_COL)
     res = {}
-    for op_type in fp32_op_list:
-        res[op_type] = {"INT8": 0, "FP32": 0}
-    for op_type in qdq_ops:
-        res[op_type] = {"INT8": 0, "FP32": 0}
+    for op_type in [*op_types, *(t for t in ALWAYS_DUMP_OP_TYPES if t not in op_types), *qdq_ops]:
+        res[op_type] = dict.fromkeys(cols, 0)
+    initializers = {init.name for init in model.graph.initializer}
 
     for node in model.graph.node:
         if node.name.endswith("_quant"):
@@ -868,21 +899,35 @@ def dump_model_op_stats(model, quantize_config, fp32_op_list):
                 origin_op_type = "LSTM"
             elif origin_op_type == "QEmbedLayerNormalization":
                 origin_op_type = "EmbedLayerNormalization"
-            res[origin_op_type]["INT8"] += 1
+            if origin_op_type in res:
+                res[origin_op_type][INT8_COL] += 1
 
         elif node.op_type in qdq_ops:
-            res[node.op_type]["INT8"] += 1
+            res[node.op_type][INT8_COL] += 1
 
         elif node.op_type in res:
-            res[node.op_type]["FP32"] += 1
+            if node.op_type in PASS_THROUGH_OPS:
+                res[node.op_type][FP32_BLOCKED_COL] += 1
+            elif node.op_type in WEIGHT_BEARING_OPS and (
+                len(node.input) < 2 or node.input[1] not in initializers
+            ):
+                res[node.op_type][FP32_BLOCKED_COL] += 1
+            else:
+                res[node.op_type][FP32_QUANTIZABLE_COL] += 1
+    return res
 
-    field_names = ["Op Type", "Total", "INT8", "FP32"]
+
+def dump_model_op_stats(model, quantize_config, fp32_op_list):
+    res = collect_op_quant_stats(model, fp32_op_list)
+
+    field_names = ["Op Type", "Total", INT8_COL, FP32_QUANTIZABLE_COL, FP32_BLOCKED_COL]
     output_data = [
         [
             op_type,
             sum(res[op_type].values()),
-            res[op_type]["INT8"],
-            res[op_type]["FP32"],
+            res[op_type][INT8_COL],
+            res[op_type][FP32_QUANTIZABLE_COL],
+            res[op_type][FP32_BLOCKED_COL],
         ]
         for op_type in res.keys()
     ]

--- a/onnx_neural_compressor/quantization/algorithm_entry.py
+++ b/onnx_neural_compressor/quantization/algorithm_entry.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import pathlib
+import pickle
 import tempfile
 from typing import Union
 
@@ -126,16 +128,37 @@ def static_quantize_entry(
 
     config_mapping = quant_config.to_config_mapping(model=model)
 
-    calibration_data_reader.rewind()
-    augment = calibrate.ONNXRTAugment(
-        model,
-        calibration_data_reader,
-        dump_op_types=quant_config.op_types_to_quantize,
-        execution_provider=quant_config.execution_provider,
-        iterations=list(range(0, quant_config.calibration_sampling_size)),
-    )
-    min_max = augment.dump_minmax(config_mapping)
-    quantize_params = augment.dump_calibration(config_mapping, min_max=min_max)
+    # Resumable static calibration: when the caller names a checkpoint file (extra_options
+    # ["CalibParamsCheckpointFile"]) and it exists, reuse the quantization params from the
+    # previous run and skip the augmented dump sessions entirely. Those sessions are the
+    # RAM peak of a SmoothQuant export (the augmented fp32 model + dump buffers), so a run
+    # that OOMed AFTER calibration (or during the final save) resumes without re-paying it.
+    # The file carries no model fingerprint: the caller keys its path by the full run
+    # configuration and owns invalidation.
+    ckpt_file = (getattr(quant_config, "extra_options", None) or {}).get("CalibParamsCheckpointFile")
+    if ckpt_file and os.path.exists(ckpt_file):
+        with open(ckpt_file, "rb") as f:
+            quantize_params = pickle.load(f)
+        logger.info(
+            "static-calibration checkpoint: loaded quantization params for %d tensor(s) "
+            "from %s; skipping the calibration forwards" % (len(quantize_params), ckpt_file)
+        )
+    else:
+        calibration_data_reader.rewind()
+        augment = calibrate.ONNXRTAugment(
+            model,
+            calibration_data_reader,
+            dump_op_types=quant_config.op_types_to_quantize,
+            execution_provider=quant_config.execution_provider,
+            iterations=list(range(0, quant_config.calibration_sampling_size)),
+        )
+        min_max = augment.dump_minmax(config_mapping)
+        quantize_params = augment.dump_calibration(config_mapping, min_max=min_max)
+        if ckpt_file:
+            tmp = str(ckpt_file) + ".tmp"
+            with open(tmp, "wb") as f:
+                pickle.dump(quantize_params, f)
+            os.replace(tmp, ckpt_file)
     _quantizer = quantizer.StaticQuantizer(
         model,
         config_mapping,
@@ -176,6 +199,9 @@ def _smoothquant_transform_params(quant_config):
         "SmoothQuantPercentile": "percentile",
         # Not in the StaticQuantConfig docstring but read by transform() when alpha=="auto".
         "AutoAlphaArgs": "auto_alpha_args",
+        # Resumable intermediates (smooth-calib + per-node auto-alpha checkpoints); see
+        # Smoother.transform's checkpoint_dir doc. The caller owns cache invalidation.
+        "SmoothQuantCheckpointDir": "checkpoint_dir",
     }
     params = {}
     for src, dst in mapping.items():

--- a/onnx_neural_compressor/quantization/algorithm_entry.py
+++ b/onnx_neural_compressor/quantization/algorithm_entry.py
@@ -154,6 +154,36 @@ def static_quantize_entry(
 
 
 ###################### SmoothQuant Entry ##################################
+def _smoothquant_transform_params(quant_config):
+    """Translate the SmoothQuant* keys in a StaticQuantConfig's extra_options into the
+    keyword arguments Smoother.transform expects.
+
+    quantize() routes a StaticQuantConfig (with extra_options["SmoothQuant"] == True)
+    here, but StaticQuantConfig.get_model_params_dict() only surfaces the static-quant
+    knobs. Passing that to Smoother.transform forwards NONE of the smooth knobs, so the
+    smoother silently runs with its hard-coded defaults (alpha=0.5, the [0.3, 0.7] auto
+    grid, op_types Conv+Gemm+MatMul+FusedConv) no matter what the caller set. This maps
+    the documented extra_options names to the transform() argument names so they take
+    effect.
+    """
+    eo = dict(getattr(quant_config, "extra_options", None) or {})
+    mapping = {
+        "SmoothQuantAlpha": "alpha",
+        "SmoothQuantFolding": "folding",
+        "SmoothQuantOpTypes": "op_types",
+        "SmoothQuantCalibIter": "calib_iter",
+        "SmoothQuantScalesPerOp": "scales_per_op",
+        "SmoothQuantPercentile": "percentile",
+        # Not in the StaticQuantConfig docstring but read by transform() when alpha=="auto".
+        "AutoAlphaArgs": "auto_alpha_args",
+    }
+    params = {}
+    for src, dst in mapping.items():
+        if src in eo and eo[src] is not None:
+            params[dst] = eo[src]
+    return params
+
+
 @utility.register_algo(name=constants.SMOOTH_QUANT)
 def smooth_quant_entry(
     model: Union[pathlib.Path, str],
@@ -176,7 +206,7 @@ def smooth_quant_entry(
         calibration_data_reader,
         execution_provider=getattr(quant_config, "execution_provider", "CPUExecutionProvider"),
     )
-    smoothed_model = smoother.transform(**quant_config.get_model_params_dict())
+    smoothed_model = smoother.transform(**_smoothquant_transform_params(quant_config))
     with tempfile.TemporaryDirectory(prefix="ort.quant.") as tmp_dir:
         # ORT quant API requires str input
         onnx.save_model(

--- a/onnx_neural_compressor/quantization/algorithm_entry.py
+++ b/onnx_neural_compressor/quantization/algorithm_entry.py
@@ -135,7 +135,8 @@ def static_quantize_entry(
     # that OOMed AFTER calibration (or during the final save) resumes without re-paying it.
     # The file carries no model fingerprint: the caller keys its path by the full run
     # configuration and owns invalidation.
-    ckpt_file = (getattr(quant_config, "extra_options", None) or {}).get("CalibParamsCheckpointFile")
+    extra = getattr(quant_config, "extra_options", None) or {}
+    ckpt_file = extra.get("CalibParamsCheckpointFile")
     if ckpt_file and os.path.exists(ckpt_file):
         with open(ckpt_file, "rb") as f:
             quantize_params = pickle.load(f)
@@ -151,6 +152,12 @@ def static_quantize_entry(
             dump_op_types=quant_config.op_types_to_quantize,
             execution_provider=quant_config.execution_provider,
             iterations=list(range(0, quant_config.calibration_sampling_size)),
+            # Mid-pass resume: the streaming per-tensor calibrator state (histograms /
+            # running ranges, small) is periodically pickled to <ckpt_file>.partial and
+            # already-consumed samples are skipped on the next run; the partial file is
+            # removed below once the final params land.
+            checkpoint_file=ckpt_file,
+            checkpoint_interval_sec=extra.get("CheckpointIntervalSec", 1200),
         )
         min_max = augment.dump_minmax(config_mapping)
         quantize_params = augment.dump_calibration(config_mapping, min_max=min_max)
@@ -159,6 +166,10 @@ def static_quantize_entry(
             with open(tmp, "wb") as f:
                 pickle.dump(quantize_params, f)
             os.replace(tmp, ckpt_file)
+            try:
+                os.remove(str(ckpt_file) + ".partial")
+            except FileNotFoundError:
+                pass
     _quantizer = quantizer.StaticQuantizer(
         model,
         config_mapping,
@@ -202,6 +213,9 @@ def _smoothquant_transform_params(quant_config):
         # Resumable intermediates (smooth-calib + per-node auto-alpha checkpoints); see
         # Smoother.transform's checkpoint_dir doc. The caller owns cache invalidation.
         "SmoothQuantCheckpointDir": "checkpoint_dir",
+        # Minimum seconds between MID-pass checkpoint dumps (shared with the static
+        # calibration's partial state in static_quantize_entry).
+        "CheckpointIntervalSec": "checkpoint_interval_sec",
     }
     params = {}
     for src, dst in mapping.items():

--- a/onnx_neural_compressor/quantization/algorithm_entry.py
+++ b/onnx_neural_compressor/quantization/algorithm_entry.py
@@ -158,6 +158,11 @@ def static_quantize_entry(
             # removed below once the final params land.
             checkpoint_file=ckpt_file,
             checkpoint_interval_sec=extra.get("CheckpointIntervalSec", 1200),
+            # When > 0, dump the calibrated tensors in slices of this many per augmented
+            # forward instead of all at once, bounding ORT's peak memory so a long-window
+            # calibration fits in GPU VRAM. Result-invariant (each tensor sees the same
+            # windows), so the caller leaves it out of the cache hash, like execution_provider.
+            dump_batch_size=extra.get("CalibDumpBatch", 0),
         )
         min_max = augment.dump_minmax(config_mapping)
         quantize_params = augment.dump_calibration(config_mapping, min_max=min_max)

--- a/onnx_neural_compressor/quantization/algorithm_entry.py
+++ b/onnx_neural_compressor/quantization/algorithm_entry.py
@@ -226,6 +226,30 @@ def smooth_quant_entry(
         excluded_nodes = [i.name for i in smoothed_model.graph.node if i.name.endswith("_smooth_mul")]
         quant_config.nodes_to_exclude.extend(excluded_nodes)
 
+        # Sensitivity-based mixed precision (extra_options["SmoothQuantExcludeWorst"]):
+        # the auto-alpha search already scored every smoothed node's BEST achievable QDQ
+        # loss (normalized, see Smoother.auto_alpha_losses); keep the worst offenders out
+        # of quantization entirely (they stay fp32). An int keeps that many nodes, a
+        # float in (0, 1) that fraction. Only searched nodes are rankable: with a fixed
+        # alpha or an all-pinned grid there are no losses and the option is a logged no-op.
+        exclude_worst = (getattr(quant_config, "extra_options", None) or {}).get("SmoothQuantExcludeWorst")
+        if exclude_worst:
+            losses = getattr(smoother, "auto_alpha_losses", None) or {}
+            if not losses:
+                logger.warning(
+                    "SmoothQuantExcludeWorst=%r is set but the alpha search recorded no "
+                    "per-node losses (alpha is a fixed float, or every op's alpha is "
+                    "pinned); excluding nothing." % (exclude_worst,)
+                )
+            else:
+                worst = core.select_worst_nodes(losses, exclude_worst)
+                logger.info(
+                    "SmoothQuantExcludeWorst=%r: keeping the %d most quantization-damaged "
+                    "node(s) of %d searched in fp32: %s"
+                    % (exclude_worst, len(worst), len(losses), ", ".join(worst))
+                )
+                quant_config.nodes_to_exclude.extend(worst)
+
         q_model = static_quantize_entry(
             pathlib.Path(tmp_dir).joinpath("smooth.onnx").as_posix(),
             quant_config,

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pydantic
 transformers
 prettytable
 scipy
+tqdm

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ if __name__ == "__main__":
             "py-cpuinfo",
             "pydantic",
             "transformers",
+            "tqdm",
         ],
         python_requires=">=3.8.0",
         classifiers=[


### PR DESCRIPTION
(Thank you very much for this library, it's really nice).

I am aware this is absolutely not merge-ready, I made this PR to show my changes and if you're interested I can make dedicated PRs for it.

If you're not interested and think of this as noise, then I apologize and wish you a nice day.

## Context

I had to add a bunch of features to [my fork](https://github.com/thiswillbeyourgithub/neural-compressor-fork) that were needed to improve performance especially on avoiding OOM errors on my [parakeet-v3 requantization](https://huggingface.co/Olicorne/parakeet-tdt-0.6b-v3-smoothquant-onnx).

More context on why I had to apply smoothquant to parakeet v3 [is listed here on my hugging face repo](https://huggingface.co/Olicorne/parakeet-tdt-0.6b-v3-smoothquant-onnx).

This was entirely done with Claude Code Opus (and a bit of Fable), I then used it with good success and performance.

## Expected Behavior & Potential Risk

It grew from frustration from OOM and limitations on alpha parameters initially.

## How has this PR been tested?

These changes are regression-tested from the downstream model repo (`scripts/test_quantize-int8-smoothquant.py`, T1-T30), which pins the bit-identical invariants (cache on == off, sliced dump == single-pass dump, streamed top-K percentile == stacked `np.percentile`, variable-length auto-alpha).

I'm calling it in [run.sh](https://huggingface.co/Olicorne/parakeet-tdt-0.6b-v3-smoothquant-onnx/blob/main/run.sh) in my fork if you want more reproduction.

## Dependency Change?

None

# What this fork changes (SmoothQuant static int8 path)

These are the changes on the `diy` branch versus `onnx/neural-compressor`, written
up as candidates for upstreaming. They all sit in the **SmoothQuant static int8**
path and were driven by exporting a real 0.6B FastConformer ASR encoder (long
calibration windows, wide auto-alpha grids), which surfaced several upstream bugs
and scaling walls. Grouped below as correctness fixes, memory/scaling, and new
features. Commit hashes are on this fork's `diy` branch.

## Correctness fixes

- **SmoothQuant `extra_options` are no longer silently ignored.**
  - `quantize()` routes a `StaticQuantConfig` (with `extra_options["SmoothQuant"]`)
    into `smooth_quant_entry`, which called `smoother.transform(**quant_config.get_model_params_dict())`.
    But `get_model_params_dict()` only surfaces the static-quant knobs, so NONE of
    the smooth knobs (`SmoothQuantAlpha`, `SmoothQuantOpTypes`, `AutoAlphaArgs`, ...)
    reached `transform()`: the smoother always ran with its hard-coded defaults
    (alpha=0.5, the `[0.3, 0.7]` auto grid, Conv+Gemm+MatMul+FusedConv) regardless
    of what the caller set.
  - A new `_smoothquant_transform_params()` maps the documented `extra_options` names
    to the `transform()` argument names so they take effect.
  - (in `quantization/algorithm_entry.py`)

- **The selected execution provider reaches the smoother calibration.**
  - The smoother passed `execution_provider=` to the `Calibrator`, whose constructor
    parameter is `providers=`, so the argument fell into `**kwargs` and was dropped.
  - Every smoother-calibration forward therefore ran on CPU even when the caller
    asked for CUDA. The provider list is now forwarded correctly.
  - (commit `ad8c01b`)

- **Auto-alpha search no longer runs on an exhausted dataloader.**
  - Upstream's `alpha="auto"` consumed the calibration reader during setup, so the
    per-node search saw no data and every layer silently fell back to `alpha_min`.
  - The reader is now rewound and the per-node reference activations are cached, so
    the search actually evaluates the grid (this also fixes the large-model path).
  - (commit `d6745e4`)

- **The alpha grid now includes both endpoints.**
  - Upstream built the grid with `np.arange`, which stops one step short of the
    stop value, so the maximum alpha (`alpha_max`) was never evaluated.
  - The grid is now inclusive of both `alpha_min` and `alpha_max`.
  - (commit `8d88f45`)

## Memory and scalability

- **Streaming Entropy/Percentile static calibration.**
  - Static calibration buffered every dumped activation tensor of every sample until
    the end of the loop (an in-code upstream TODO), so RAM grew as samples x tensors
    and large exports OOMed.
  - Each sample is now folded straight into its per-tensor histogram and freed; peak
    RAM no longer depends on the sample count.
  - (commit `6f69d55`)

- **The auto-alpha QDQ sub-graph session is built once per node.**
  - It was rebuilt once per (node, alpha), and originally once per (node, alpha,
    sample), so a wide alpha grid ballooned ORT arena memory and rebuild time.
  - Candidate weights are now fed as runtime inputs to a single per-node session, so
    the alpha sweep is just repeated `run()` calls.
  - (commits `594f6f9`, `f2a102f`)

- **Variable-length calibration windows are accepted.**
  - That once-per-node QDQ sub-graph baked the FIRST sample's concrete activation
    shape into its value_infos, so any later window of a different sequence length
    was rejected (`Got invalid dimensions for input ... Got: N Expected: M`).
    Calibration was silently constrained to uniformly-sized windows.
  - The activation input/output dims are now left dynamic (ORT resolves the real
    shape per `run()`, so equal-length calibration is numerically unchanged), letting
    one calibration set mix short and long clips.
  - (commit `0a22d36`)

- **Per-node activation caching across the alpha grid.**
  - Each alpha evaluation re-harvested the same reference activations for a node.
  - They are now harvested once per node and reused across the whole grid.
  - (commit `d6745e4`)

- **The large-model alpha search no longer leaks proto arena memory.**
  - Each (node, alpha) evaluation rewrote the node's weight initializer twice (scale
    then recover), and even `numpy_helper.to_array` materializes external weights into
    the proto. Under protobuf's upb backend every such write abandons the old bytes in
    the ModelProto's arena (freed only when the proto dies), so retained RAM grew with
    nodes x alphas and survived into static calibration. A 0.1-step grid OOMed an
    export where a 0.2-step grid fit.
  - Candidate weights are now scaled in numpy and fed to the QDQ-loss session directly,
    and external weights are read via a throwaway `TensorProto`, so the search retains
    nothing.
  - (commit `72de740`)

- **Memory-conservative ORT sessions for the dump/calibration passes.**
  - The augmented dump graphs return hundreds of activation tensors per forward, and
    ORT's BFC arenas grow ahead of demand and never release, so the calibration
    sessions carried ~1 GB of allocator slack on a 0.6B encoder and could abort with a
    BFCArena allocation failure on a loaded host.
  - These sessions run only a handful of forwards, so a new
    `conservative_session_resources()` disables the CPU arena and pins the CUDA arena
    to `kSameAsRequested` growth, applied to both the static-calibration session and the
    smoother's dump session.
  - (commit `6c6e0cf`)

- **Streaming per-channel percentile in the smoother calibration.**
  - The smoother calibration stacked every sample's activations and called
    `np.percentile` once at the end, so RAM grew as samples x frames x channels
    (~6 GB per ~400 s window, hundreds of GB for a multi-window export) and thrashed.
  - Because the high percentiles SmoothQuant uses (99.999 by default) depend only on
    the largest values per channel, each sample is now folded into a per-channel
    running top-K reducer (`StreamingChannelPercentile`) and freed. The reducer
    reproduces `np.percentile` bit-for-bit (its float64 promotion and `t >= 0.5` lerp
    branch included) and re-checks that K was large enough for the actual row count, so
    a result can never be silently wrong.
  - (commit `e61fb24`)

- **Sliced static-calibration dump to bound VRAM.**
  - Static int8 calibration augments the model so EVERY calibrated tensor becomes a
    graph output, and ORT keeps all graph outputs resident for the whole forward, so a
    long window peaks every activation at once (per-layer attention-score MatMuls are
    ~0.8 GB each near a FastConformer's ~400 s reach) and overflows VRAM.
  - With `extra_options["CalibDumpBatch"] > 0` the tensors are dumped in slices of that
    many graph outputs, each slice its own augment + forward over the same (rewound)
    windows, so only one slice is resident at a time. The per-tensor ranges stay
    bit-identical to the single-pass dump (it only trades extra forwards for a smaller
    peak).
  - (commit `a495323`)

## New features and usability

- **Per-op-type alpha override in the auto-alpha search.**
  - Pin an op type to a fixed alpha, or give it its own `min:max:step` grid, instead
    of one global grid for all smoothed ops.
  - (commit `280b123`)

- **Sensitivity-based mixed precision (`extra_options["SmoothQuantExcludeWorst"]`).**
  - The auto-alpha search records every smoothed node's best achievable QDQ loss,
    normalized by that node's reference-output energy so it is comparable across nodes
    (`Smoother.auto_alpha_losses`).
  - Setting the option to an int n (or a fraction in (0, 1)) keeps the n worst-quantizing
    nodes out of quantization entirely (they stay fp32), trading a little file size for
    accuracy on the layers int8 hurts most. Only searched nodes are rankable, so with a
    fixed alpha it is a logged no-op.
  - (commit `89b4363`)

- **Resumable, crash-safe exports.**
  - Given a checkpoint directory (`extra_options["SmoothQuantCheckpointDir"]` plus
    `CalibParamsCheckpointFile`), the smoother persists its expensive intermediates as
    they are produced and reloads whatever already exists on the next run: the smoother
    calibration, the per-node alpha search (append-only `alphas.jsonl`, one line per
    completed node, so an interrupted multi-hour search resumes from the last completed
    node), and the static-calibration quantization params.
  - Both per-sample calibration loops also checkpoint MID-pass, time-gated by
    `CheckpointIntervalSec` (default 1200 s) so a fast pass pays no IO, so an OOM- or
    time-killed pass resumes from the last sample instead of restarting.
  - All writes are atomic (temp + `os.replace`) so a crash mid-write never leaves a
    truncated file. Checkpoints carry no model fingerprint (the caller keys the
    directory by its full run configuration and owns invalidation) but DO record the
    slice partition behind the static-calibration partial, so a resume with a changed
    `CalibDumpBatch` or tensor set is discarded rather than misapplied.
  - (commits `55a3c75`, `628f57f`, `9eb2d4e`, `0c58d7b`)

- **Per-layer alpha summary logged after the search.**
  - A histogram per op type plus one line per smoothed node showing the alpha the
    search picked, so the export is auditable instead of opaque.
  - (commit `0a532e1`)

- **Richer quantization statistics table.**
  - fp32 ops are split into "quantizable" (weight-bearing, the quantizer could convert
    them directly) versus "needs an int8 input" (weightless/pass-through ops that only
    convert inside an int8 region), and the Reshape/Transpose glue rows are always shown.
  - (commit `e792411`)

- **Progress bars and quieter logs.**
  - tqdm progress bars over the alpha search and both calibration passes, and the
    per-evaluation ORT warning spam is silenced.
  - (commits `82e3451`, `9f0e94b`)

---

